### PR TITLE
Fix smart card signing; add page navigation, all-pages signing, and an About section

### DIFF
--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -1,0 +1,224 @@
+# CEI Web Signer - Technical Lessons Learned
+
+## macOS CryptoTokenKit (CTK) and Smart Card Access
+
+### CTK Architecture
+- On modern macOS, there is **no standalone `pcscd`**. PC/SC is provided by `ctkpcscd`, an XPC service launched on-demand by `ctkd`.
+- Key processes:
+  - `ctkd` — CryptoTokenKit daemon (runs as both `_ctkd` system user and current user). Token watcher that monitors smart card readers.
+  - `ctkpcscd` — PC/SC daemon (runs as current user). Provides the PC/SC API that all smart card tools use.
+  - `ctkahp` — Authentication helper.
+- `ctkd` runs in two domains: `system` (as `_ctkd` user) and `gui/<uid>` (as current user).
+- `ctkpcscd` is an XPC service started by `ctkd`, not a standalone launchd service.
+
+### CTK Does NOT Block python-pkcs11 — CORRECTED 2026-08-06
+- **This section previously claimed CTK holds an exclusive PKCS#11 lock and that all
+  PKCS#11 calls hang. That is wrong for `python-pkcs11`, and acting on it caused a
+  real outage** (see "The kill_ctkd Regression" below).
+- Measured with CTK fully running (`ctkd`, `ctkpcscd`, `ctkahp` all alive), nothing killed:
+  - `pkcs11.lib(...)` loads in **0.2s**
+  - `get_slots(token_present=True)` returns in **2–19s**
+  - opening a public session, reading certificates: works
+  - `opensc-tool --list-readers` still works *after* the PKCS#11 call — **no PC/SC poisoning**
+- The old note "(This may not apply to python-pkcs11)" was the correct instinct. It doesn't.
+- PyKCS11 may still hang — untested since the switch to `python-pkcs11`. Do not
+  generalize from it back to `python-pkcs11`.
+
+### Slot Enumeration Is Progressive and Nondeterministic
+- The Idemia driver discovers the card's applications **lazily**. Successive runs returned:
+  `[1]` → `[1]` → `[1, 2, 3]` → `[1, 2]`.
+- A cold `get_slots()` typically returns **only slot 1**. Slot 2 (ADVANCED SIGNATURE) can
+  take **12–20 seconds** and several enumerations to appear. Slot 3 (QSCD) sometimes never does.
+- **Never take a single snapshot of `get_slots()` and conclude a slot is missing.**
+  Poll until the wanted slot appears or a timeout expires — see `find_slot()` in `app.py`.
+
+### Warm-up Is Paid Once Per Process — Don't Cache Sessions
+- `pkcs11.lib(path)` is already cached by python-pkcs11 (`lib(p) is lib(p)` → `True`).
+- Measured across three sequential sign-shaped operations in one process:
+
+  | request | `lib()` | `find_slot(2)` | `get_token()` |
+  |---|---|---|---|
+  | 1 (cold) | 0.19s | **7.97s** | 0.19s |
+  | 2 | 0.00s | 0.00s | 0.12s |
+  | 3 | 0.00s | 0.00s | 0.12s |
+
+- So in the long-lived Flask process, only the **first** file pays the warm-up.
+  Batch signing does **not** need a cached PKCS#11 session; adding one would mean
+  holding an authenticated session in memory across requests for no measured gain.
+- `/api/slots` caches its enumeration result per library path for the same reason
+  (first call ~12.5s, subsequent ~0.03s), and drops the cache when the card is removed.
+
+### The kill_ctkd Regression (what NOT to do)
+- Commit `6e29cd6` added `kill_ctkd()` into the signing path, escalated to
+  `osascript … "pkill -9 ctkd; pkill -9 ctkahp" with administrator privileges`.
+- Result: `ctkd` was killed, taking `ctkpcscd` (its XPC child, and the actual PC/SC
+  provider) down with it. **The reader went invisible to every tool** while still
+  enumerated on USB (`ioreg` showed it present and active). Recovery required a physical re-plug.
+- Signing then failed for all files with `Slot 2 not found`, producing 0 signed documents
+  and a zero-entry ZIP.
+- It was also **entirely unnecessary** — PKCS#11 works fine alongside CTK (above).
+- `test_app.py::NoCtkKillTests` now fails the build if any CTK-killing code returns.
+
+### PC/SC Level Access Works Fine
+- `opensc-tool --list-readers` works instantly alongside CTK — it uses PC/SC, not PKCS#11.
+- `pyscard` (Python PC/SC library) also works instantly — can connect to the card, send APDUs, read ATR.
+- The distinction is: **PC/SC = shared access, PKCS#11 = exclusive access (blocked by CTK)**.
+
+### NEVER Kill CTK
+- Killing `ctkd` with `pkill -9`:
+  - It respawns via launchd in ~0.5 seconds — too fast to sneak in a PKCS#11 call.
+  - Keeping a background loop killing it continuously doesn't help — the reader becomes invisible.
+- Killing `ctkpcscd`:
+  - **Makes the smart card reader completely invisible** to all tools (including `opensc-tool`).
+  - The reader stays invisible until re-plugged (sometimes to a different USB port).
+- `launchctl disable system/com.apple.ctkpcscd`:
+  - **CATASTROPHIC** — persists across reboots, completely disables PC/SC.
+  - Must be re-enabled with `launchctl enable system/com.apple.ctkpcscd` (requires sudo).
+  - Even after re-enabling, the service may be stuck in a crashed state requiring a **full system restart**.
+- Non-sudo `pkill` cannot kill CTK processes running as root (`_ctkd`).
+- sudo `pkill` via `osascript` works but causes the problems above.
+
+### Recovery from Broken CTK State
+- If CTK services are disabled (`launchctl print-disabled gui/<uid>` shows them as disabled):
+  - Re-enable with `launchctl enable gui/<uid>/com.apple.ctkpcscd` and `launchctl enable gui/<uid>/com.apple.ctkahp`.
+  - Also re-enable in system domain: `launchctl enable system/com.apple.ctkpcscd` (requires sudo).
+- If CTK processes are in a `-9` crashed state (`launchctl list | grep ctk` shows exit code -9):
+  - `launchctl start`, `launchctl kickstart`, `launchctl bootstrap` may all fail with I/O errors.
+  - **A system restart (or at minimum logout/login) is required** to reset the services.
+- Re-plugging the reader (especially to a different USB port) can sometimes restore visibility after a CTK kill.
+
+---
+
+## Romanian CEI (Carte Electronica de Identitate) Smart Card
+
+### Card Hardware
+- Manufactured by **Idemia**.
+- Uses a **Generic Smart Card Reader Interface** (USB CCID).
+- ATR: `3BDF96008131FE458073842 1E05569780000808307900024`
+- Reader driver: `fr.apdu.ccid.smartcardccid` (ifd-ccid.bundle).
+
+### PKCS#11 Driver
+- Path: `/Library/Application Support/com.idemia.idplug/lib/libidplug-pkcs11.2.7.0.dylib`
+- When it works (CTK not holding the reader), it exposes **3 slots**:
+  - Slot 1: `PKI User PIN` (Authentication)
+  - Slot 2: `ADVANCED SIGNATURE PIN` (Qualified Electronic Signature)
+  - Slot 3: `QSCD PIN` (Qualified Signature Creation Device)
+- Slot enumeration (`get_slots()`) takes ~7.5 seconds even when it works.
+- **The Idemia PKCS#11 library poisons the PC/SC connection**: after any call to it via PyKCS11, even `opensc-tool` stops seeing the reader until re-plug. (This may not apply to python-pkcs11.)
+
+### Card File Structure
+- **Not standard PKCS#15** — `pkcs15-tool` returns "Card is invalid or cannot be handled".
+- **No standard AIDs match**: IAS-ECC, ICAO eMRTD, PIV, OpenPGP, Idemia COSMO — all return 6A82 (file not found) or 6A86 (incorrect parameters).
+- Master File (3F00) can be selected successfully (SW=9000).
+- EF.DIR (2F00) does not exist.
+- No child DFs found with standard file IDs (scanned 0x0000-0xFF30 range with P1=01 and P1=02).
+- The card uses a **proprietary file structure** that only the Idemia PKCS#11 driver knows how to navigate.
+
+### macOS Smart Card Integration
+- `system_profiler SPSmartCardsDataType` sees the reader and ATR but **no CTK token driver claims the card**.
+- Installed token drivers (OpenSC, paperLESS vTOKEN, Apple PIV) don't recognize the Idemia CEI.
+- `security list-smartcards` returns "No smartcards found" — the card is not in the macOS keychain.
+- Despite not recognizing the card, CTK still holds the PC/SC connection and blocks PKCS#11 access.
+
+### Signing Architecture
+- pyHanko's `PKCS11Signer` is used for PDF signing with the card.
+- Certificate labels: `Certificate ECC Advanced Signature`, key labels: `Private Key ECC Advanced Signature`.
+- The card uses **ECDSA** (not RSA) for signatures.
+- Signing requires: open PKCS#11 session with PIN, find cert/key by label, pyHanko handles the rest.
+
+---
+
+## PDF Page Tree Traps
+
+### /Pages/Kids Is a Tree, Not a Page List
+- `pdf_reader.root['/Pages']['/Kids'][page_ix]` is **wrong**. `/Kids` may contain
+  intermediate `/Pages` nodes, each with their own `/Kids`. It only works when the
+  tree happens to be flat and one level deep.
+- Measured on the real ANMAP documents:
+
+  | file | `/Count` | `len(/Kids)` | kid types | pages where flat indexing failed |
+  |---|---|---|---|---|
+  | 01_Raspuns_la_intampinare_ANMAP_v9 | 10 | 2 | `/Pages`, `/Pages` | 8 of 10 |
+  | 02_Anexa_1_Preturi_echipament_FINAL | 12 | 2 | `/Pages`, `/Pages` | 10 of 12 |
+  | 03_Anexa_2_Panou_Fundata_FINAL | 6 | 6 | all `/Page` | 0 of 6 (flat, worked by luck) |
+
+- Word/LibreOffice exports are often flat; anything that has been merged, split, or
+  round-tripped through another tool usually is not. Testing on one flat file proves nothing.
+- Use pyHanko's `PdfHandler.find_page_for_modification(page_ix)` — it walks the tree properly.
+
+### /MediaBox Is Inheritable
+- A `/Page` may carry no `/MediaBox` and inherit it from an ancestor `/Pages` node.
+- `page.get('/MediaBox', [0, 0, 612, 792])` therefore silently yields **US Letter** for
+  a page that is actually A4 (595.2 × 841.92) — misplacing the signature ~50pt vertically.
+- Walk up `/Parent` until a `/MediaBox` is found. See `get_page_media_box()` in `app.py`.
+- Known remaining gap: `/Rotate` is also inheritable and is **not** yet accounted for.
+  Signature placement on a rotated page will be wrong.
+
+---
+
+## PyInstaller Bundling Issues
+
+### `sys.executable` Points to App Binary
+- In a PyInstaller bundle, `sys.executable` points to the app binary (e.g., `CEI PDF Signer.app/.../CEI PDF Signer`), NOT to a Python interpreter.
+- Any `subprocess.run([sys.executable, '-c', ...])` will **re-launch the entire application**, causing an infinite loop.
+- Fix: avoid subprocess with `sys.executable`; use `multiprocessing` with `fork` start method instead (which doesn't need a Python interpreter path).
+
+### multiprocessing in PyInstaller
+- Requires `freeze_support()` at the start of `main.py`.
+- Must use `set_start_method('fork')` — the default `spawn` method on macOS would also try to re-launch the binary.
+
+### PATH in Bundled App
+- The bundled app may not have `/usr/local/bin` in PATH.
+- Must explicitly add it for `opensc-tool` and other system tools to be found:
+  ```python
+  if '/usr/local/bin' not in os.environ.get('PATH', ''):
+      os.environ['PATH'] = '/usr/local/bin:' + os.environ.get('PATH', '')
+  ```
+
+---
+
+## Frontend Timing Considerations
+
+- PKCS#11 slot enumeration takes ~7.5 seconds with the Idemia library.
+- Frontend must have generous timeouts (30s+) and polling intervals (15s+).
+- Must guard against overlapping detection requests (use an `isDetecting` flag).
+
+---
+
+## Viable vs Non-Viable Approaches
+
+### What Works
+| Tool/Library | Level | Works with CTK | Notes |
+|---|---|---|---|
+| `opensc-tool --list-readers` | PC/SC | Yes | Instant, reliable detection |
+| `pyscard` (Python) | PC/SC | Yes | Can connect, send APDUs, read ATR |
+| `system_profiler SPSmartCardsDataType` | System | Yes | Shows reader + ATR |
+
+### What Doesn't Work (with CTK active)
+| Tool/Library | Level | Issue |
+|---|---|---|
+| PyKCS11 | PKCS#11 | Hangs indefinitely (unverified since the switch away from it) |
+| ~~python-pkcs11~~ | PKCS#11 | **Corrected 2026-08-06: works fine with CTK alive.** Slot enum is slow/progressive, not blocked |
+| `pkcs11-tool` | PKCS#11 | Hangs indefinitely |
+| `pkcs15-tool` | OpenSC/PC/SC | "Card is invalid" (proprietary card) |
+
+### Approaches That Are Dangerous
+| Approach | Why |
+|---|---|
+| Killing CTK (`pkill ctkd/ctkpcscd`) | Makes reader invisible, may require reboot to recover |
+| `launchctl disable` CTK services | Persists across reboots, breaks all smart card access |
+| Sudo password prompts in polling loops | Creates infinite password dialog loop |
+
+---
+
+## Open Questions / Future Investigation
+
+1. **Can `pyscard` be used for the full signing flow?** Requires reverse-engineering the Idemia card's proprietary APDU protocol (file selection, PIN verification, certificate reading, signature generation). The PKCS#11 driver knows these APDUs but they're not publicly documented.
+
+2. **Is there a way to make PKCS#11 coexist with CTK?** Perhaps a configuration flag in the Idemia driver, or a macOS setting to exclude the reader from CTK management.
+
+3. **Can we use `sc_auth` or Security framework?** The card isn't recognized by any CTK token driver, so macOS keychain integration doesn't work. A custom CTK token extension could potentially bridge this.
+
+4. **Does the Idemia macOS software include a CTK token driver?** The `com.idemia.idplug` package may have a `.appex` token plugin that should be installed to make CTK work properly with the card, potentially resolving the PKCS#11 conflict.
+
+5. **Would disabling CTK's smart card pairing for this specific reader work?** `sudo defaults write /Library/Preferences/com.apple.security.smartcard DisabledTokens -array-add ...` or similar.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ CEI PDF Signer allows you to digitally sign PDF documents using the qualified ce
 - Modern, intuitive web interface
 - Sign multiple PDF documents at once
 - Visual signature placement on each document
+- Page navigation: jump to any page number, first page, last page
+- Apply the signature mark to every page of a document in one click
 - Support for ECDSA certificates from CEI
 - Automatic smart card reader detection
 - Direct export to Downloads folder
@@ -81,15 +83,32 @@ cd cei-web-signer
 
 If macOS takes control of the reader (shows "Smart card detected" notification) or the app hangs on startup:
 
-**Cause:** macOS CryptoTokenKit tries to use the reader simultaneously.
+**First, try this — it fixes it almost every time:** unplug the reader and plug it back
+in, preferably into a USB port on the Mac itself rather than through a hub. If the reader
+is visible to macOS but no card is found, re-seat the card in the reader.
 
-**Solution:**
+**Do not kill CryptoTokenKit.** `pkill ctkd` (or `ctkpcscd`, or `ctkahp`) takes down the
+PC/SC service that CryptoTokenKit provides, which makes the reader **completely invisible
+to every application** until it is physically re-plugged. It does not help: PKCS#11 access
+works fine while CryptoTokenKit is running. Verified on macOS 26.5 with IdPlug 2.7.0 —
+loading the library takes 0.2s and enumerating slots 2–20s, with all CryptoTokenKit
+daemons alive and untouched.
+
+Slot enumeration being slow is normal. The IdPlug driver discovers the card's applications
+progressively: the first read often shows only slot 1, with the signature slot appearing
+several seconds later. The app polls until it settles, so the first detection after
+inserting a card can take 10–20 seconds.
+
+**Only if re-plugging does not help**, you can disable macOS's smart-card services. This is
+a persistent, system-wide change that affects every application, so treat it as a last
+resort:
 ```bash
 sudo defaults write /Library/Preferences/com.apple.security.smartcard allowSmartCard -bool false
 sudo defaults write /Library/Preferences/com.apple.security.smartcard UserPairing -bool false
 sudo defaults write /Library/Preferences/com.apple.security.smartcard useIFDCCID -bool false
 # Restart your Mac for changes to take effect
 ```
+Reverse it with the same commands using `-bool true`.
 
 #### Debugging CryptoTokenKit
 
@@ -119,6 +138,8 @@ CEI PDF Signer permite semnarea digitala a documentelor PDF folosind certificatu
 - Interfata web moderna si intuitiva
 - Semnare multipla documente PDF
 - Selectare vizuala a pozitiei semnaturii pe document
+- Navigare pagini: salt la orice numar de pagina, prima pagina, ultima pagina
+- Aplicarea semnaturii pe toate paginile documentului dintr-un singur click
 - Suport pentru certificatele ECDSA de pe CEI
 - Detectare automata a cititorului de carduri
 - Export direct in folderul Downloads
@@ -179,15 +200,32 @@ cd cei-web-signer
 
 Daca macOS preia controlul asupra cititorului (apare notificare "Smart card detected") sau aplicatia se blocheaza la pornire:
 
-**Cauza:** macOS CryptoTokenKit incearca sa foloseasca cititorul simultan cu aplicatia noastra.
+**Incercati intai asta — rezolva problema aproape de fiecare data:** scoateti cititorul si
+introduceti-l din nou, de preferat intr-un port USB de pe Mac, nu printr-un hub. Daca
+cititorul este vizibil dar cardul nu este gasit, reintroduceti cardul in cititor.
 
-**Solutie:**
+**Nu opriti CryptoTokenKit.** `pkill ctkd` (sau `ctkpcscd`, sau `ctkahp`) opreste serviciul
+PC/SC furnizat de CryptoTokenKit, iar cititorul devine **complet invizibil pentru toate
+aplicatiile** pana cand este scos si introdus din nou fizic. Nu ajuta: accesul PKCS#11
+functioneaza normal cat timp CryptoTokenKit ruleaza. Verificat pe macOS 26.5 cu IdPlug
+2.7.0 — incarcarea bibliotecii dureaza 0.2s, iar enumerarea sloturilor 2–20s, cu toate
+procesele CryptoTokenKit pornite si neatinse.
+
+Enumerarea lenta a sloturilor este normala. Driverul IdPlug descopera aplicatiile de pe card
+progresiv: prima citire arata deseori doar slotul 1, iar slotul de semnare apare dupa cateva
+secunde. Aplicatia reincearca pana se stabilizeaza, deci prima detectare dupa introducerea
+cardului poate dura 10–20 de secunde.
+
+**Doar daca reintroducerea cititorului nu ajuta**, puteti dezactiva serviciile de smart card
+din macOS. Este o modificare permanenta, la nivel de sistem, care afecteaza toate
+aplicatiile, deci folositi-o ca ultima solutie:
 ```bash
 sudo defaults write /Library/Preferences/com.apple.security.smartcard allowSmartCard -bool false
 sudo defaults write /Library/Preferences/com.apple.security.smartcard UserPairing -bool false
 sudo defaults write /Library/Preferences/com.apple.security.smartcard useIFDCCID -bool false
 # Restartati Mac-ul pentru ca setarile sa aiba efect
 ```
+Se revine cu aceleasi comenzi folosind `-bool true`.
 
 #### Debugging CryptoTokenKit
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CEI PDF Signer
 
-**[🌐 Website](https://bancuthekind.github.io/cei-pdf-signer)** | **[📥 Download](https://github.com/BancuTheKind/cei-pdf-signer/releases)**
+**[🌐 Website](https://sudondream.github.io/cei-pdf-signer)** | **[📥 Download](https://github.com/sudondream/cei-pdf-signer/releases)**
 
 Free, open-source macOS application for digitally signing PDF documents using the Romanian Electronic Identity Card (CEI).
 
@@ -49,7 +49,7 @@ CEI PDF Signer allows you to digitally sign PDF documents using the qualified ce
 #### Option 2: From Source
 
 ```bash
-git clone https://github.com/BancuTheKind/cei-pdf-signer.git
+git clone https://github.com/sudondream/cei-pdf-signer.git
 cd cei-web-signer
 ./run.sh
 ```
@@ -166,7 +166,7 @@ CEI PDF Signer permite semnarea digitala a documentelor PDF folosind certificatu
 #### Varianta 2: Din sursa
 
 ```bash
-git clone https://github.com/BancuTheKind/cei-pdf-signer.git
+git clone https://github.com/sudondream/cei-pdf-signer.git
 cd cei-web-signer
 ./run.sh
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ CEI PDF Signer allows you to digitally sign PDF documents using the qualified ce
 
 #### Software
 - macOS 10.13 or newer
-- [IDPlugManager](https://www.inteligent.ro/idplugmanager/) - official CEI software (provides the PKCS#11 library)
+- [IDPlugManager](https://hub.mai.gov.ro/aplicatie-cei) - official CEI software (provides the PKCS#11 library)
 
 ### Installation
 
@@ -153,7 +153,7 @@ CEI PDF Signer permite semnarea digitala a documentelor PDF folosind certificatu
 
 #### Software
 - macOS 10.13 sau mai nou
-- [IDPlugManager](https://www.inteligent.ro/idplugmanager/) - software-ul oficial pentru CEI (instaleaza biblioteca PKCS#11)
+- [IDPlugManager](https://hub.mai.gov.ro/aplicatie-cei) - software-ul oficial pentru CEI (instaleaza biblioteca PKCS#11)
 
 ### Instalare
 

--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import base64
 import tempfile
 import hashlib
 import subprocess
+import threading
 import time
 from datetime import datetime
 from pathlib import Path
@@ -58,6 +59,10 @@ CORS(app)
 app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50MB max
 app.config['UPLOAD_FOLDER'] = tempfile.mkdtemp()
 
+# Ensure /usr/local/bin is in PATH (needed for opensc-tool in bundled app)
+if '/usr/local/bin' not in os.environ.get('PATH', ''):
+    os.environ['PATH'] = '/usr/local/bin:' + os.environ.get('PATH', '')
+
 # Default PKCS#11 library for Romanian CEI
 DEFAULT_PKCS11_LIB = "/Library/Application Support/com.idemia.idplug/lib/libidplug-pkcs11.2.7.0.dylib"
 
@@ -73,18 +78,301 @@ def get_pkcs11_lib_path(custom_path=None):
     return os.environ.get('PKCS11_LIB', DEFAULT_PKCS11_LIB)
 
 
-def kill_ctkd():
-    """Kill CryptoTokenKit daemon to release smart card reader.
-    macOS CTK grabs exclusive PC/SC access on card insertion,
-    blocking PKCS#11 access. Killing it forces release."""
-    for proc in ('ctkd', 'ctkahp'):
+# The Idemia driver discovers the card's applications progressively: a cold
+# get_slots() returns only slot 1, and slots 2 (ADVANCED SIGNATURE) and 3 (QSCD)
+# show up ~20s later. A single snapshot loses that race and reports "slot not found".
+SLOT_WAIT_TIMEOUT = 45.0
+SLOT_POLL_INTERVAL = 2.0
+
+
+def find_slot(lib, slot_id, timeout=SLOT_WAIT_TIMEOUT, poll_interval=SLOT_POLL_INTERVAL,
+              now=time.monotonic, sleep=time.sleep):
+    """Find a PKCS#11 slot by ID, re-enumerating while the driver warms up.
+
+    Returns (slot, seen_slot_ids). slot is None if it never appeared before the
+    timeout; seen_slot_ids is from the last enumeration, for the error message.
+    """
+    deadline = now() + timeout
+    seen = []
+    while True:
+        slots = lib.get_slots(token_present=True)
+        seen = [s.slot_id for s in slots]
+        for slot in slots:
+            if slot.slot_id == slot_id:
+                return slot, seen
+        if now() >= deadline:
+            return None, seen
+        sleep(poll_interval)
+
+
+# Enumerating the card's real slots has to outlast the same warm-up, but must
+# finish inside the frontend's 30s abort.
+SLOT_SETTLE_TIMEOUT = 20.0
+
+_slot_cache = {}          # lib_path -> [slot dicts]
+_slot_lock = threading.Lock()
+
+
+def clear_slot_cache():
+    """Forget cached slots - called when the card is no longer present."""
+    with _slot_lock:
+        _slot_cache.clear()
+
+
+def detect_reader():
+    """Return (reader_name, card_present) via PC/SC.
+
+    Instant, and works alongside CryptoTokenKit - unlike PKCS#11 enumeration,
+    which is slow. Used as a cheap gate before the expensive part.
+    """
+    result = subprocess.run(['opensc-tool', '--list-readers'],
+                            capture_output=True, text=True, timeout=10)
+    output = result.stdout.strip()
+    if not output or 'No smart card readers' in output:
+        return None, False
+
+    for line in output.split('\n'):
+        line = line.strip()
+        if not line or line.startswith('#') or line.startswith('Nr.'):
+            continue
+        parts = line.split(None, 3)  # nr, card_present, features, name
+        if len(parts) < 2:
+            continue
         try:
-            subprocess.run(['pkill', '-9', proc],
-                           capture_output=True, timeout=5)
+            slot_nr = int(parts[0])
+        except ValueError:
+            continue
+        if parts[1].lower() == 'yes':
+            name = parts[3] if len(parts) >= 4 else (
+                parts[2] if len(parts) >= 3 else f'Reader {slot_nr}')
+            return name, True
+
+    return None, False
+
+
+def enumerate_slots(lib, settle_timeout=SLOT_SETTLE_TIMEOUT, poll_interval=SLOT_POLL_INTERVAL,
+                    now=time.monotonic, sleep=time.sleep):
+    """List the card's real PKCS#11 slots with their token labels.
+
+    Polls until the slot set stops growing (two consecutive reads add nothing)
+    or settle_timeout expires, keeping the union of everything seen. The driver
+    reveals slots progressively and has been observed dropping one between
+    reads, so a single snapshot under-reports.
+    """
+    deadline = now() + settle_timeout
+    found = {}
+    stable = 0
+
+    while True:
+        try:
+            slots = lib.get_slots(token_present=True)
         except Exception:
-            pass
-    # Give PC/SC a moment to reclaim the reader
-    time.sleep(0.5)
+            slots = []
+
+        grew = False
+        for slot in slots:
+            if slot.slot_id in found:
+                continue
+            grew = True
+            try:
+                label = (slot.get_token().label or '').strip() or f'Slot {slot.slot_id}'
+            except Exception:
+                label = f'Slot {slot.slot_id}'
+            found[slot.slot_id] = label
+
+        if found and not grew:
+            stable += 1
+            if stable >= 2:
+                break
+        else:
+            stable = 0
+
+        if now() >= deadline:
+            break
+        sleep(poll_interval)
+
+    return [{'id': sid, 'label': found[sid]} for sid in sorted(found)]
+
+
+# Guard against /Parent cycles in malformed page trees.
+MAX_PAGE_TREE_DEPTH = 64
+DEFAULT_MEDIA_BOX = [0.0, 0.0, 612.0, 792.0]  # US Letter
+
+
+def get_page_media_box(pdf_reader, page_ix):
+    """MediaBox of page `page_ix`, walking the page tree and honouring inheritance.
+
+    Two traps this avoids:
+      * /Pages/Kids is a TREE, not a flat page list. Intermediate /Pages nodes
+        mean Kids[page_ix] is wrong - IndexError, or silently the wrong page.
+      * /MediaBox is an inheritable attribute. A page may carry none and take
+        its nearest ancestor's, so defaulting to Letter misplaces signatures
+        on A4 by ~50pt.
+
+    Raises pyhanko PdfError if page_ix is out of range; callers should range-check first.
+    """
+    page_ref, _resources = pdf_reader.find_page_for_modification(page_ix)
+    node = page_ref.get_object()
+
+    for _ in range(MAX_PAGE_TREE_DEPTH):
+        if node is None:
+            break
+        box = node.get('/MediaBox')
+        if box is not None:
+            return [float(v) for v in box]
+        parent = node.get('/Parent')
+        node = parent.get_object() if parent is not None else None
+
+    # /MediaBox is required by the spec, so reaching here means a broken file.
+    return list(DEFAULT_MEDIA_BOX)
+
+
+# Points kept between a stamp and the page edge when a box has to be slid inside.
+BOX_MARGIN = 4.0
+
+
+def clamp_box(x, y, width, height, media_box, margin=BOX_MARGIN):
+    """Slide a box (PDF coords, lower-left origin) inside the media box.
+
+    Returns the (possibly unchanged) lower-left corner. A box drawn on an A4
+    portrait page keeps its exact position on every other A4 portrait page; only
+    a page that is too small or the wrong orientation moves it. A box larger
+    than the page is pinned at the margin rather than pushed off the other side.
+    """
+    x0, y0, x1, y1 = (float(v) for v in media_box)
+    min_x, min_y = x0 + margin, y0 + margin
+    max_x, max_y = x1 - width - margin, y1 - height - margin
+
+    cx = min_x if max_x < min_x else min(max(x, min_x), max_x)
+    cy = min_y if max_y < min_y else min(max(y, min_y), max_y)
+    return cx, cy
+
+
+def resolve_box(pdf_reader, box, page_count):
+    """Frontend box -> (page_ix, x, y, width, height) in PDF coordinates.
+
+    The frontend measures from the top-left of the rendered page; PDF runs from
+    the bottom-left of the MediaBox. Result is clamped inside the target page.
+    """
+    page_ix = int(box.get('page', 1)) - 1
+    if page_ix < 0 or page_ix >= page_count:
+        raise ValueError(f'Signature box is on page {page_ix + 1}, but this document '
+                         f'has {page_count} page(s).')
+
+    width = float(box.get('width', 200))
+    height = float(box.get('height', 70))
+    media_box = get_page_media_box(pdf_reader, page_ix)
+
+    x = media_box[0] + float(box.get('x', 50))
+    y = media_box[3] - float(box.get('y', 50)) - height
+    x, y = clamp_box(x, y, width, height, media_box)
+    return page_ix, x, y, width, height
+
+
+def document_has_signature(pdf_reader):
+    """True if the PDF already carries a filled-in signature field.
+
+    Stamping writes to page content, which invalidates a pre-existing signature.
+    Merely appending a new signature field does not, so this only gates stamping.
+    """
+    try:
+        acro = pdf_reader.root.get('/AcroForm')
+        if acro is None:
+            return False
+        for ref in acro.get_object().get('/Fields', []):
+            field = ref.get_object()
+            if field.get('/FT') == '/Sig' and field.get('/V') is not None:
+                return True
+    except Exception:
+        return False
+    return False
+
+
+def build_stamp_style():
+    """The signature appearance, shared by the real field and the page stamps.
+
+    Both go through this so a stamped page looks identical to the signed one.
+    """
+    seal_graphic = RawContent(
+        box=None,
+        data=b'''
+        q
+        0.2 0.4 0.8 RG  % Blue stroke color
+        0.9 0.95 1 rg  % Light blue fill
+        2 w  % Line width
+        50 35 40 30 re S  % Outer rectangle
+        0.2 0.4 0.8 rg  % Blue fill for inner elements
+        % Draw decorative lines
+        15 60 m 135 60 l S  % Top line
+        15 10 m 135 10 l S  % Bottom line
+        Q
+        '''
+    )
+    return TextStampStyle(
+        stamp_text='DIGITALLY SIGNED\n%(signer)s\n%(ts)s',
+        text_box_style=TextBoxStyle(font_size=28),
+        border_width=3,
+        border_color=(0.2, 0.4, 0.8),
+        background=seal_graphic,
+        background_opacity=0.15,
+    )
+
+
+def get_signer_common_name(signer):
+    """CN from the signing certificate, for the stamp text."""
+    try:
+        return signer.signing_cert.subject.native.get('common_name') or 'Unknown'
+    except Exception:
+        return 'Unknown'
+
+
+def _ensure_page_contents(pdf_writer, page_ix):
+    """Give a page an empty /Contents stream if it has none.
+
+    A page with no /Contents is legal (an entirely blank page), but pyHanko's
+    add_stream_to_page does a raw_get('/Contents') and raises KeyError on it.
+    """
+    from pyhanko.pdf_utils import generic
+
+    page_ref, _ = pdf_writer.find_page_for_modification(page_ix)
+    page = page_ref.get_object()
+    if '/Contents' in page:
+        return
+
+    empty = pdf_writer.add_object(generic.StreamObject(stream_data=b''))
+    page[generic.NameObject('/Contents')] = empty
+    pdf_writer.update_container(page)
+
+
+def apply_visual_stamps(pdf_writer, pdf_reader, boxes, page_count,
+                        signer_name, timestamp=None):
+    """Draw a signature-lookalike stamp for each box. Returns how many were applied.
+
+    These are ordinary page content, not signature fields. Applied before
+    sign_pdf(), so the single real signature's byte range covers them - they
+    cannot be altered without invalidating it.
+    """
+    if not boxes:
+        return 0
+
+    from pyhanko.pdf_utils.layout import BoxConstraints
+    from pyhanko.stamp import TextStamp
+
+    style = build_stamp_style()
+    applied = 0
+    for box in boxes:
+        page_ix, x, y, width, height = resolve_box(pdf_reader, box, page_count)
+        _ensure_page_contents(pdf_writer, page_ix)
+        params = {'signer': signer_name}
+        if timestamp is not None:
+            params['ts'] = timestamp
+        TextStamp(
+            pdf_writer, style,
+            text_params=params,
+            box=BoxConstraints(width=width, height=height),
+        ).apply(page_ix, x, y)
+        applied += 1
+    return applied
 
 
 @app.route('/')
@@ -107,65 +395,61 @@ def api_status():
 
 @app.route('/api/slots')
 def api_slots():
-    """Detect available smart card slots"""
-    if not PKCS11_AVAILABLE:
-        return jsonify({'slots': [], 'error': 'PyKCS11 not installed'})
+    """Report the card's real PKCS#11 slots.
 
-    # Get custom path from query string if provided
-    custom_path = request.args.get('pkcs11_path')
-    lib_path = get_pkcs11_lib_path(custom_path)
-    if not os.path.exists(lib_path):
-        return jsonify({'slots': [], 'error': f'PKCS11 library not found at: {lib_path}'})
+    Cheap PC/SC presence check first, then actual slot enumeration. The result
+    is cached per library path, because enumeration costs ~8-20s on a cold
+    driver and the frontend polls this every 15s.
+    """
+    try:
+        reader_name, card_present = detect_reader()
+    except FileNotFoundError:
+        return jsonify({'slots': [], 'error': 'opensc-tool not found. Please install OpenSC.'})
+    except subprocess.TimeoutExpired:
+        return jsonify({'slots': [], 'error': 'Reader detection timed out.'})
+    except Exception as e:
+        return jsonify({'slots': [], 'error': f'Error: {str(e)}'})
 
-    last_error = None
-    for attempt in range(2):
+    if not card_present:
+        # Card pulled - drop the cache so the next insert re-enumerates.
+        clear_slot_cache()
+        return jsonify({'slots': [], 'error': 'No smart card detected. Please insert your CEI card.'})
+
+    if not PYHANKO_AVAILABLE:
+        return jsonify({'slots': [], 'error': 'python-pkcs11 not installed'})
+
+    lib_path = get_pkcs11_lib_path(request.args.get('pkcs11_path'))
+
+    # Serialize enumeration: a second concurrent poll should wait and then hit
+    # the cache rather than hammer the driver.
+    with _slot_lock:
+        cached = _slot_cache.get(lib_path)
+        if cached:
+            return jsonify({'slots': cached})
+
         try:
-            if attempt > 0:
-                # First attempt failed — kill CryptoTokenKit and retry
-                kill_ctkd()
-
-            lib = PyKCS11.PyKCS11Lib()
-            lib.load(lib_path)
-
-            # Get slots with tokens present (card inserted)
-            slots = lib.getSlotList(tokenPresent=True)
-
-            if not slots:
-                return jsonify({'slots': [], 'error': 'No smart card detected'})
-
-            slot_info = []
-            for slot_id in slots:
-                try:
-                    token_info = lib.getTokenInfo(slot_id)
-                    slot_info.append({
-                        'id': slot_id,
-                        'label': token_info.label.strip(),
-                        'model': token_info.model.strip(),
-                        'manufacturer': token_info.manufacturerID.strip(),
-                    })
-                except:
-                    slot_info.append({
-                        'id': slot_id,
-                        'label': f'Slot {slot_id}',
-                        'model': 'Unknown',
-                        'manufacturer': 'Unknown',
-                    })
-
-            return jsonify({'slots': slot_info})
-
-        except PyKCS11.PyKCS11Error as e:
-            last_error = f'Smart card error: {str(e)}'
+            slot_info = enumerate_slots(pkcs11.lib(lib_path))
         except Exception as e:
-            last_error = f'Error: {str(e)}'
+            return jsonify({'slots': [], 'error': f'Could not read card slots: {e}'})
 
-    return jsonify({'slots': [], 'error': last_error})
+        if not slot_info:
+            return jsonify({'slots': [], 'error':
+                            'Card detected but no PKCS#11 slots available. Re-seat the card and retry.'})
+
+        for slot in slot_info:
+            slot['model'] = reader_name or ''
+            slot['manufacturer'] = 'Idemia'
+
+        _slot_cache[lib_path] = slot_info
+
+    return jsonify({'slots': slot_info})
 
 
 @app.route('/api/certificate', methods=['POST'])
 def api_get_certificate():
-    """Get certificate from smart card"""
-    if not PKCS11_AVAILABLE:
-        return jsonify({'error': 'PyKCS11 not installed'}), 500
+    """Get certificate from smart card using python-pkcs11"""
+    if not PYHANKO_AVAILABLE:
+        return jsonify({'error': 'python-pkcs11 not installed'}), 500
 
     data = request.json
     if not data:
@@ -177,41 +461,28 @@ def api_get_certificate():
     if not pin:
         return jsonify({'error': 'PIN required'}), 400
 
+    session = None
     try:
         custom_path = data.get('pkcs11_path')
         lib_path = get_pkcs11_lib_path(custom_path)
-        lib = PyKCS11.PyKCS11Lib()
-        lib.load(lib_path)
+        lib = pkcs11.lib(lib_path)
 
-        # Check available slots first
-        available_slots = lib.getSlotList(tokenPresent=True)
-        if slot_id not in available_slots:
-            return jsonify({'error': f'Slot {slot_id} not available. Available slots: {available_slots}. Please click "Detect Smart Card" again.'}), 400
+        target_slot, available = find_slot(lib, slot_id)
+        if not target_slot:
+            return jsonify({'error': f'Slot {slot_id} not available. Available slots: {available}. Please click "Detect Smart Card" again.'}), 400
 
-        session = lib.openSession(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION)
-        session.login(pin)
-        
+        token = target_slot.get_token()
+        session = token.open(user_pin=pin)
+
         # Find certificates
-        certs = session.findObjects([(CKA_CLASS, CKO_CERTIFICATE)])
-        
+        from pkcs11 import ObjectClass, Attribute
         cert_info = []
-        for cert in certs:
-            attrs = session.getAttributeValue(cert, [CKA_VALUE, CKA_LABEL])
-            cert_der = bytes(attrs[0])
-            # Handle label - might be string, bytes, or list of ints depending on PyKCS11 version
-            raw_label = attrs[1]
-            if not raw_label:
-                label = 'Unknown'
-            elif isinstance(raw_label, str):
-                label = raw_label
-            elif isinstance(raw_label, (bytes, bytearray)):
-                label = raw_label.decode('utf-8', errors='replace')
-            elif isinstance(raw_label, (list, tuple)) and raw_label and isinstance(raw_label[0], int):
-                label = ''.join(chr(c) for c in raw_label)
-            else:
-                label = str(raw_label)
-            
-            # Parse certificate if cryptography is available
+        for cert in session.get_objects({Attribute.CLASS: ObjectClass.CERTIFICATE}):
+            cert_der = bytes(cert[Attribute.VALUE])
+            label = cert.get(Attribute.LABEL, 'Unknown') or 'Unknown'
+            if isinstance(label, bytes):
+                label = label.decode('utf-8', errors='replace')
+
             try:
                 from cryptography import x509
                 from cryptography.hazmat.backends import default_backend
@@ -219,7 +490,7 @@ def api_get_certificate():
                 subject = cert_obj.subject.rfc4514_string()
                 issuer = cert_obj.issuer.rfc4514_string()
                 not_after = cert_obj.not_valid_after_utc.isoformat()
-                
+
                 cert_info.append({
                     'label': label,
                     'subject': subject,
@@ -227,34 +498,32 @@ def api_get_certificate():
                     'valid_until': not_after,
                     'der_base64': base64.b64encode(cert_der).decode('ascii')
                 })
-            except:
+            except Exception:
                 cert_info.append({
                     'label': label,
                     'der_base64': base64.b64encode(cert_der).decode('ascii')
                 })
-        
-        session.logout()
-        session.closeSession()
-        
+
         return jsonify({'certificates': cert_info})
-    
-    except PyKCS11.PyKCS11Error as e:
-        error_msg = str(e)
-        if 'CKR_PIN_INCORRECT' in error_msg:
-            return jsonify({'error': 'Incorrect PIN. Please check your PIN and try again.'}), 401
-        if 'CKR_PIN_LOCKED' in error_msg:
-            return jsonify({'error': 'PIN is locked. Too many incorrect attempts.'}), 401
-        if 'CKR_TOKEN_NOT_PRESENT' in error_msg:
-            return jsonify({'error': 'Smart card not detected. Please insert your CEI card.'}), 500
-        if 'CKR_SLOT_ID_INVALID' in error_msg:
-            return jsonify({'error': f'Invalid slot {slot_id}. Please click "Detect Smart Card" and select the correct slot.'}), 500
-        if 'CKR_USER_NOT_LOGGED_IN' in error_msg:
-            return jsonify({'error': 'Session expired. Please try again.'}), 500
-        return jsonify({'error': f'Smart card error: {error_msg}'}), 500
+
+    except pkcs11.exceptions.PinIncorrect:
+        return jsonify({'error': 'Incorrect PIN. Please check your PIN and try again.'}), 401
+    except pkcs11.exceptions.PinLocked:
+        return jsonify({'error': 'PIN is locked. Too many incorrect attempts.'}), 401
+    except pkcs11.exceptions.TokenNotPresent:
+        return jsonify({'error': 'Smart card not detected. Please insert your CEI card.'}), 500
+    except pkcs11.exceptions.SlotIDInvalid:
+        return jsonify({'error': f'Invalid slot {slot_id}. Please click "Detect Smart Card" and select the correct slot.'}), 500
     except Exception as e:
         import traceback
         traceback.print_exc()
         return jsonify({'error': f'Error: {str(e)}'}), 500
+    finally:
+        if session:
+            try:
+                session.close()
+            except Exception:
+                pass
 
 
 @app.route('/api/sign', methods=['POST'])
@@ -321,18 +590,11 @@ def api_sign_pdf():
 
         # Load PKCS#11 library and find the right slot
         lib = pkcs11.lib(lib_path)
-        slots = lib.get_slots(token_present=True)
 
-        # Find slot by ID - python-pkcs11 uses slot array, not slot IDs directly
-        target_slot = None
-        for slot in slots:
-            # The slot_id from frontend matches the PKCS#11 slot number
-            if slot.slot_id == slot_id:
-                target_slot = slot
-                break
-
+        target_slot, available = find_slot(lib, slot_id)
         if not target_slot:
-            return jsonify({'error': f'Slot {slot_id} not found'}), 400
+            return jsonify({'error': f'Slot {slot_id} not found. Available slots: {available}. '
+                                     f'Check that the card is fully seated in the reader.'}), 400
 
         # Open session with PIN
         token = target_slot.get_token()
@@ -359,54 +621,44 @@ def api_sign_pdf():
         pdf_reader = PdfFileReader(pdf_input, strict=False)
         pdf_writer = IncrementalPdfFileWriter.from_reader(pdf_reader)
 
+        page_count = int(pdf_reader.root['/Pages'].get('/Count', 0))
+
         # Add signature field if visible
         if visible:
-            # Get page dimensions to convert coordinates
-            # Frontend uses top-left origin, PDF uses bottom-left
-            page_obj = pdf_reader.root['/Pages']['/Kids'][sig_page]
-            media_box = page_obj.get('/MediaBox', [0, 0, 612, 792])
-            page_height = float(media_box[3]) - float(media_box[1])
-
-            # Convert Y coordinate from top-left to bottom-left origin
-            pdf_y = page_height - sig_y - sig_height
+            try:
+                sig_page, pdf_x, pdf_y, sig_width, sig_height = resolve_box(
+                    pdf_reader,
+                    {'page': sig_page + 1, 'x': sig_x, 'y': sig_y,
+                     'width': sig_width, 'height': sig_height},
+                    page_count,
+                )
+            except ValueError as e:
+                return jsonify({'error': str(e)}), 400
 
             sig_field_spec = SigFieldSpec(
                 sig_field_name='Signature1',
                 on_page=sig_page,
-                box=(sig_x, pdf_y, sig_x + sig_width, pdf_y + sig_height),
+                box=(pdf_x, pdf_y, pdf_x + sig_width, pdf_y + sig_height),
             )
             append_signature_field(pdf_writer, sig_field_spec)
 
-        # Create stamp background graphic (seal-like circle pattern)
-        # Using PDF drawing commands for a circular seal
-        seal_graphic = RawContent(
-            box=None,  # Will be set by the stamp
-            data=b'''
-            q
-            0.2 0.4 0.8 RG  % Blue stroke color
-            0.9 0.95 1 rg  % Light blue fill
-            2 w  % Line width
-            50 35 40 30 re S  % Outer rectangle
-            0.2 0.4 0.8 rg  % Blue fill for inner elements
-            % Draw decorative lines
-            15 60 m 135 60 l S  % Top line
-            15 10 m 135 10 l S  % Bottom line
-            Q
-            '''
-        )
+        # Every box after the first becomes a visual stamp. Only box 0 is a real
+        # signature field - one qualified signature covers the whole document,
+        # and because stamping happens before sign_pdf() the stamps fall inside
+        # its byte range and cannot be altered without invalidating it.
+        extra_boxes = signature_boxes[1:] if signature_boxes else []
+        if extra_boxes:
+            if document_has_signature(pdf_reader):
+                return jsonify({'error': 'This document already contains a signature. '
+                                         'Stamping every page would modify page content and '
+                                         'invalidate it. Keep a single signature box.'}), 400
+            try:
+                apply_visual_stamps(pdf_writer, pdf_reader, extra_boxes, page_count,
+                                    get_signer_common_name(signer))
+            except ValueError as e:
+                return jsonify({'error': str(e)}), 400
 
-        # Create stamp style with larger text and stamp-like appearance
-        text_style = TextBoxStyle(
-            font_size=28,  # Large font to fill the box
-        )
-        stamp_style = TextStampStyle(
-            stamp_text='DIGITALLY SIGNED\n%(signer)s\n%(ts)s',
-            text_box_style=text_style,
-            border_width=3,
-            border_color=(0.2, 0.4, 0.8),  # Blue border
-            background=seal_graphic,
-            background_opacity=0.15,  # Subtle background
-        )
+        stamp_style = build_stamp_style()
 
         # Create PdfSigner with stamp style
         pdf_signer = PdfSigner(
@@ -465,19 +717,30 @@ def api_sign_pdf():
                 pass
 
 
+DOWNLOADS_FOLDER = os.path.expanduser('~/Downloads')
+
+
+def reveal_in_finder(path):
+    """Open Finder with the given path selected."""
+    subprocess.run(['open', '-R', path], check=False)
+
+
 @app.route('/api/save-files', methods=['POST'])
 def api_save_files():
     """Save signed files to Downloads folder and open in Finder"""
-    import subprocess
     import zipfile
-    from io import BytesIO
 
     data = request.json
     if not data or 'files' not in data:
         return jsonify({'error': 'No files provided'}), 400
 
     files_data = data['files']
-    downloads_folder = os.path.expanduser('~/Downloads')
+    if not files_data:
+        # Never write a zero-entry ZIP - that just looks like a successful save
+        # of nothing. If we got here, every document failed to sign.
+        return jsonify({'error': 'No signed documents to save - all documents failed to sign.'}), 400
+
+    downloads_folder = DOWNLOADS_FOLDER
 
     try:
         saved_files = []
@@ -499,7 +762,7 @@ def api_save_files():
             saved_files.append(file_path)
 
             # Open Finder and select the file
-            subprocess.run(['open', '-R', file_path], check=False)
+            reveal_in_finder(file_path)
 
         else:
             # Multiple files - create ZIP
@@ -519,7 +782,7 @@ def api_save_files():
             saved_files.append(zip_path)
 
             # Open Finder and select the ZIP
-            subprocess.run(['open', '-R', zip_path], check=False)
+            reveal_in_finder(zip_path)
 
         return jsonify({
             'success': True,

--- a/app.py
+++ b/app.py
@@ -717,6 +717,33 @@ def api_sign_pdf():
                 pass
 
 
+# Destinations offered by the About section. The frontend sends one of these
+# KEYS, never a URL, so this endpoint cannot be turned into an arbitrary-URL
+# (or arbitrary-argument) opener.
+ABOUT_LINKS = {
+    'website': 'https://plixco.ro',
+    'github': 'https://github.com/sudondream',
+    'linkedin': 'https://www.linkedin.com/in/sudondream/',
+    'email': 'mailto:contact@plixco.ro',
+}
+
+
+@app.route('/api/open-external', methods=['POST'])
+def api_open_external():
+    """Open an About link in the user's default browser or mail client.
+
+    Needed because pywebview would otherwise follow the link in the app window
+    itself, replacing the signer UI with the target page.
+    """
+    data = request.json or {}
+    url = ABOUT_LINKS.get(data.get('key'))
+    if not url:
+        return jsonify({'error': 'Unknown link'}), 400
+
+    subprocess.run(['open', url], check=False)
+    return jsonify({'success': True})
+
+
 DOWNLOADS_FOLDER = os.path.expanduser('~/Downloads')
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -449,7 +449,7 @@
             <a href="#features" data-lang="ro">Functii</a>
             <a href="#install" data-lang="en">Install</a>
             <a href="#install" data-lang="ro">Instalare</a>
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer" target="_blank">GitHub</a>
+            <a href="https://github.com/sudondream/cei-pdf-signer" target="_blank">GitHub</a>
             <div class="lang-toggle">
                 <button class="lang-btn active" onclick="setLang('en')">EN</button>
                 <button class="lang-btn" onclick="setLang('ro')">RO</button>
@@ -467,12 +467,12 @@
         <p data-lang="en">Free, open-source application for digitally signing PDF documents using the Romanian Electronic Identity Card.</p>
         <p data-lang="ro">Aplicatie gratuita si open-source pentru semnarea digitala a documentelor PDF folosind Cartea de Identitate Electronica din Romania.</p>
         <div class="cta-buttons">
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer/releases" class="btn btn-primary">
+            <a href="https://github.com/sudondream/cei-pdf-signer/releases" class="btn btn-primary">
                 <span>⬇️</span>
                 <span data-lang="en">Download for macOS</span>
                 <span data-lang="ro">Descarca pentru macOS</span>
             </a>
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer" class="btn btn-secondary">
+            <a href="https://github.com/sudondream/cei-pdf-signer" class="btn btn-secondary">
                 <span>📂</span>
                 <span data-lang="en">View Source</span>
                 <span data-lang="ro">Vezi Codul</span>
@@ -625,7 +625,7 @@
                     <p data-lang="en">Get the latest release from GitHub</p>
                     <p data-lang="ro">Descarca ultima versiune de pe GitHub</p>
                     <code>
-                        <a href="https://github.com/BancuTheKind/cei-pdf-signer/releases" target="_blank" style="color: var(--accent)">github.com/BancuTheKind/cei-pdf-signer/releases</a>
+                        <a href="https://github.com/sudondream/cei-pdf-signer/releases" target="_blank" style="color: var(--accent)">github.com/sudondream/cei-pdf-signer/releases</a>
                     </code>
                 </div>
             </div>
@@ -654,13 +654,13 @@
 
     <footer>
         <div class="footer-links">
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer" target="_blank">GitHub</a>
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer/releases" target="_blank" data-lang="en">Releases</a>
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer/releases" target="_blank" data-lang="ro">Versiuni</a>
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer/issues" target="_blank" data-lang="en">Report Issue</a>
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer/issues" target="_blank" data-lang="ro">Raporteaza Problema</a>
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer/blob/main/LICENSE" target="_blank" data-lang="en">MIT License</a>
-            <a href="https://github.com/BancuTheKind/cei-pdf-signer/blob/main/LICENSE" target="_blank" data-lang="ro">Licenta MIT</a>
+            <a href="https://github.com/sudondream/cei-pdf-signer" target="_blank">GitHub</a>
+            <a href="https://github.com/sudondream/cei-pdf-signer/releases" target="_blank" data-lang="en">Releases</a>
+            <a href="https://github.com/sudondream/cei-pdf-signer/releases" target="_blank" data-lang="ro">Versiuni</a>
+            <a href="https://github.com/sudondream/cei-pdf-signer/issues" target="_blank" data-lang="en">Report Issue</a>
+            <a href="https://github.com/sudondream/cei-pdf-signer/issues" target="_blank" data-lang="ro">Raporteaza Problema</a>
+            <a href="https://github.com/sudondream/cei-pdf-signer/blob/main/LICENSE" target="_blank" data-lang="en">MIT License</a>
+            <a href="https://github.com/sudondream/cei-pdf-signer/blob/main/LICENSE" target="_blank" data-lang="ro">Licenta MIT</a>
         </div>
         <p class="footer-note" data-lang="en">Made with <span class="heart">❤️</span> for the Romanian community</p>
         <p class="footer-note" data-lang="ro">Facut cu <span class="heart">❤️</span> pentru comunitatea romaneasca</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -594,8 +594,8 @@
                     <div class="req-icon">🔧</div>
                     <div>
                         <h4>IDPlugManager</h4>
-                        <p data-lang="en">Official PKCS#11 driver from <a href="https://www.inteligent.ro/idplugmanager/" target="_blank" style="color: var(--accent)">inteligent.ro</a></p>
-                        <p data-lang="ro">Driver PKCS#11 oficial de la <a href="https://www.inteligent.ro/idplugmanager/" target="_blank" style="color: var(--accent)">inteligent.ro</a></p>
+                        <p data-lang="en">Official PKCS#11 driver from <a href="https://hub.mai.gov.ro/aplicatie-cei" target="_blank" style="color: var(--accent)">HUB MAI ROMANIA</a></p>
+                        <p data-lang="ro">Driver PKCS#11 oficial de la <a href="https://hub.mai.gov.ro/aplicatie-cei" target="_blank" style="color: var(--accent)">HUB MAI ROMANIA</a></p>
                     </div>
                 </div>
             </div>
@@ -612,8 +612,8 @@
                 <div class="step-content">
                     <h4 data-lang="en">Install IDPlugManager</h4>
                     <h4 data-lang="ro">Instaleaza IDPlugManager</h4>
-                    <p data-lang="en">Download and install from <a href="https://www.inteligent.ro/idplugmanager/" target="_blank" style="color: var(--accent)">inteligent.ro</a></p>
-                    <p data-lang="ro">Descarca si instaleaza de pe <a href="https://www.inteligent.ro/idplugmanager/" target="_blank" style="color: var(--accent)">inteligent.ro</a></p>
+                    <p data-lang="en">Download and install from <a href="https://hub.mai.gov.ro/aplicatie-cei" target="_blank" style="color: var(--accent)">HUB MAI ROMANIA</a></p>
+                    <p data-lang="ro">Descarca si instaleaza de pe <a href="https://hub.mai.gov.ro/aplicatie-cei" target="_blank" style="color: var(--accent)">HUB MAI ROMANIA</a></p>
                 </div>
             </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -514,6 +514,14 @@
             </div>
 
             <div class="feature-card">
+                <div class="feature-icon">📑</div>
+                <h3 data-lang="en">Sign Every Page</h3>
+                <h3 data-lang="ro">Semnatura pe Toate Paginile</h3>
+                <p data-lang="en">Place the signature mark on every page in one click, with page navigation to jump anywhere in the document. One legally binding signature covers them all.</p>
+                <p data-lang="ro">Aplica semnatura pe toate paginile dintr-un singur click, cu navigare rapida oriunde in document. O singura semnatura cu valoare legala le acopera pe toate.</p>
+            </div>
+
+            <div class="feature-card">
                 <div class="feature-icon">🔐</div>
                 <h3 data-lang="en">Secure by Design</h3>
                 <h3 data-lang="ro">Securitate prin Design</h3>

--- a/docs/superpowers/specs/2026-08-06-page-nav-and-all-pages-signature-design.md
+++ b/docs/superpowers/specs/2026-08-06-page-nav-and-all-pages-signature-design.md
@@ -1,0 +1,121 @@
+# Page Navigation and "Apply Signature to All Pages"
+
+Date: 2026-08-06
+Status: approved
+
+## Goal
+
+Two additions to CEI PDF Signer:
+
+1. Page navigation: jump to a page number, go to first page, go to last page.
+2. "Apply signature to all pages": replicate the signature box drawn on the current
+   page onto every other page of the selected document.
+
+## Decisions Taken
+
+### One qualified signature, visual marks elsewhere
+
+A PDF digital signature is one cryptographic object bound to one signature field with
+one visible appearance on one page. "Signature on all pages" is therefore ambiguous.
+
+**Chosen:** one real signature field on the page the user drew, and a visual stamp on
+every other page. The stamps are page content, not signature fields.
+
+Because stamping happens *before* signing, the single signature's byte range covers
+every stamp — they cannot be altered without invalidating the signature. This mirrors
+the paper convention of initialling every page while signing once.
+
+Rejected: a real signature field per page. It would cost one PKCS#11 sign operation and
+one incremental update per page (the user's documents are image-heavy — the 6-page file
+already produces 10.7MB), show 12 signatures on a 12-page document in Adobe, and amount
+to signing the same document 12 times, which a recipient may query.
+
+### Placement: same spot, clamped inside the page
+
+**Chosen:** use the exact coordinates of the drawn box. If any part would fall outside
+the target page, slide it back inside keeping a 4pt margin.
+
+On uniformly-sized documents (all three of the user's files are A4, 595.2 x 841.92) this
+is a no-op and every stamp lands identically.
+
+```
+M = 4                                  # margin, PDF points
+x = min(max(x, M), pageW - w - M)
+y = min(max(y, M), pageH - h - M)
+```
+
+Rejected: proportional placement (can push a stamp further into the content area on
+landscape pages than expected). Rejected: whitespace detection — it requires parsing
+every page's content stream, there is no server-side renderer available, results vary
+per document, and it is hard to test.
+
+## Scope Assumptions
+
+- "Apply to all pages" acts on the **currently selected document only**.
+- The replicated stamp keeps the **same size** as the drawn box; it is not scaled per page.
+
+## Design
+
+### A. Page navigation (frontend only)
+
+Toolbar becomes `⏮ ◀ Page [6] of 6 ▶ ⏭`, with the page number an editable input.
+
+- `goToPage(n)` clamps to `1..totalPages`, ignores non-numeric input, re-renders.
+- The input commits on Enter and on blur; invalid input reverts to the current page.
+- `firstPage()` / `lastPage()`, disabled at the bounds like the existing prev/next buttons.
+
+No backend involvement.
+
+### B. Apply to all pages (frontend)
+
+A toolbar button, enabled when the selected document has at least one box on the current
+page. It replicates that page's box(es) to every other page, clamped per page.
+
+Clamping needs each page's true size, so `pageSizes[fileIdx]` is cached on PDF load from
+pdf.js (`getPage(i).getViewport({scale: 1})`). Clamping client-side as well as server-side
+means the on-screen preview matches the output exactly — the user can page through and
+see where each stamp will land before signing.
+
+Signature boxes are already stored in PDF points with a top-left origin, which is what the
+backend expects, so no coordinate-model change is needed.
+
+### C. Backend (`app.py`)
+
+Today `app.py` takes `signature_boxes[0]` and silently discards the rest, so boxes drawn
+on other pages never appear. New contract:
+
+- `signature_boxes[0]` → the real signature field (`Signature1`; existing behaviour).
+- `signature_boxes[1:]` → visual stamps via `TextStamp(writer, style).apply(page_ix, x, y)`.
+
+This fixes the existing silent-drop bug as a side effect.
+
+Order of operations:
+
+1. Build `IncrementalPdfFileWriter` from the reader.
+2. `append_signature_field` for box 0.
+3. Apply a `TextStamp` for each remaining box.
+4. `pdf_signer.sign_pdf(writer)`.
+
+Stamp text is built from the signing certificate's CN plus the timestamp so it reads the
+same as the real signature appearance. The backend re-clamps against the true MediaBox
+(via `get_page_media_box`, which already handles page-tree walking and MediaBox
+inheritance); the frontend clamp exists for preview accuracy, the backend clamp is
+authoritative.
+
+### D. Error handling
+
+- Signature box on a page beyond the document → HTTP 400 (already implemented).
+- Box larger than the page → pinned at the margin and allowed to overflow, rather than
+  silently resized.
+- **Document already signed by someone else** → adding stamps modifies page content,
+  which invalidates any pre-existing signature. Appending a signature field alone does
+  not. Detect existing signature fields and refuse the all-pages stamp with a clear
+  message, while still permitting a normal single signature.
+
+### E. Testing
+
+- `clamp_box()` as a pure function: portrait, landscape, oversized box, tiny page.
+- N boxes produce exactly one signature field and N-1 stamps in the output.
+- All-pages stamping over the synthetic nested-page-tree PDF from the page-tree fix.
+- Refusal path when the source document already contains a signature.
+- The existing 18 tests must continue to pass.

--- a/main.py
+++ b/main.py
@@ -129,7 +129,7 @@ def main():
     )
 
     def start_app():
-        """Kill CTK, start Flask, and navigate to it once ready"""
+        """Start Flask and navigate to it once ready"""
         # Start Flask server in background thread
         server_thread = threading.Thread(target=start_server, args=(port,), daemon=True)
         server_thread.start()

--- a/main.py
+++ b/main.py
@@ -9,7 +9,6 @@ import os
 import threading
 import socket
 import time
-
 # Ensure we can find our modules when running as a bundled app
 if getattr(sys, 'frozen', False):
     # Running as bundled app
@@ -130,7 +129,7 @@ def main():
     )
 
     def start_app():
-        """Start Flask and navigate to it once ready"""
+        """Kill CTK, start Flask, and navigate to it once ready"""
         # Start Flask server in background thread
         server_thread = threading.Thread(target=start_server, args=(port,), daemon=True)
         server_thread.start()

--- a/templates/index.html
+++ b/templates/index.html
@@ -339,6 +339,26 @@
             cursor: not-allowed;
         }
 
+        .btn-clear-boxes {
+            margin-left: 8px;
+            padding: 5px 12px;
+            font-size: 13px;
+            color: #ff6464;
+            background: rgba(255, 100, 100, 0.1);
+            border: 1px solid rgba(255, 100, 100, 0.35);
+            border-radius: 6px;
+            cursor: pointer;
+        }
+
+        .btn-clear-boxes:hover:not(:disabled) {
+            background: rgba(255, 100, 100, 0.2);
+        }
+
+        .btn-clear-boxes:disabled {
+            opacity: 0.3;
+            cursor: not-allowed;
+        }
+
         .zoom-controls {
             display: flex;
             align-items: center;
@@ -912,6 +932,10 @@
                 <button class="btn-all-pages" id="all-pages-btn" onclick="applyBoxToAllPages()"
                         title="Copy this page's signature box to every page">
                     Apply to all pages
+                </button>
+                <button class="btn-clear-boxes" id="clear-boxes-btn" onclick="clearAllBoxes()"
+                        title="Remove every signature box from this document">
+                    Clear all
                 </button>
                 <div class="zoom-controls">
                     <button onclick="zoomOut()">-</button>
@@ -1568,8 +1592,32 @@
 
         function updateAllPagesButton() {
             const btn = document.getElementById('all-pages-btn');
-            if (!btn) return;
-            btn.disabled = totalPages < 2 || boxesOnCurrentPage().length === 0;
+            if (btn) btn.disabled = totalPages < 2 || boxesOnCurrentPage().length === 0;
+
+            const clearBtn = document.getElementById('clear-boxes-btn');
+            if (clearBtn) {
+                const count = (signatureBoxes[selectedFileIndex] || []).length;
+                clearBtn.disabled = count === 0;
+                clearBtn.textContent = count > 1 ? `Clear all (${count})` : 'Clear all';
+            }
+        }
+
+        function clearAllBoxes() {
+            const boxes = signatureBoxes[selectedFileIndex] || [];
+            if (boxes.length === 0) return;
+
+            // Only worth confirming when it would undo more than a single box.
+            if (boxes.length > 1 &&
+                !confirm(`Remove all ${boxes.length} signature boxes from this document?`)) {
+                return;
+            }
+
+            signatureBoxes[selectedFileIndex] = [];
+            renderSignatureBoxes();
+            renderFileList();
+            updateSigBoxesInfo();
+            updateSignButton();
+            updatePageNav();
         }
 
         function applyBoxToAllPages() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -302,6 +302,43 @@
             font-size: 14px;
         }
 
+        .page-info #page-input {
+            width: 44px;
+            padding: 3px 4px;
+            margin: 0 2px;
+            text-align: center;
+            font-size: 14px;
+            color: #fff;
+            background: rgba(255, 255, 255, 0.07);
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 4px;
+        }
+
+        .page-info #page-input:focus {
+            outline: none;
+            border-color: #00d4ff;
+        }
+
+        .btn-all-pages {
+            margin-left: 16px;
+            padding: 5px 12px;
+            font-size: 13px;
+            color: #00d4ff;
+            background: rgba(0, 212, 255, 0.1);
+            border: 1px solid rgba(0, 212, 255, 0.35);
+            border-radius: 6px;
+            cursor: pointer;
+        }
+
+        .btn-all-pages:hover:not(:disabled) {
+            background: rgba(0, 212, 255, 0.2);
+        }
+
+        .btn-all-pages:disabled {
+            opacity: 0.3;
+            cursor: not-allowed;
+        }
+
         .zoom-controls {
             display: flex;
             align-items: center;
@@ -862,10 +899,20 @@
         <div class="center-panel">
             <div class="preview-toolbar" id="preview-toolbar" style="display: none;">
                 <div class="page-nav">
+                    <button onclick="firstPage()" id="first-btn" title="First page">&#9198;</button>
                     <button onclick="prevPage()" id="prev-btn">&#9664;</button>
-                    <span class="page-info">Page <span id="page-num">1</span> of <span id="page-count">1</span></span>
+                    <span class="page-info">Page
+                        <input type="text" id="page-input" value="1" inputmode="numeric"
+                               onchange="commitPageInput()" onblur="commitPageInput()"
+                               onkeydown="if(event.key==='Enter'){event.preventDefault();this.blur();}">
+                        of <span id="page-count">1</span></span>
                     <button onclick="nextPage()" id="next-btn">&#9654;</button>
+                    <button onclick="lastPage()" id="last-btn" title="Last page">&#9197;</button>
                 </div>
+                <button class="btn-all-pages" id="all-pages-btn" onclick="applyBoxToAllPages()"
+                        title="Copy this page's signature box to every page">
+                    Apply to all pages
+                </button>
                 <div class="zoom-controls">
                     <button onclick="zoomOut()">-</button>
                     <span id="zoom-level">100%</span>
@@ -1013,6 +1060,7 @@
         let pdfDoc = null;
         let currentPage = 1;
         let totalPages = 0;
+        let pageSizes = [];   // unscaled {width, height} per page, PDF points
         let scale = 1.0;
         let signatureBoxes = {};
         let availableSlots = [
@@ -1200,6 +1248,14 @@
                 pdfDoc = await pdfjsLib.getDocument({data: data}).promise;
                 totalPages = pdfDoc.numPages;
                 currentPage = 1;
+
+                // Unscaled page sizes in PDF points, so "apply to all pages" can
+                // clamp each box against the real geometry of its target page.
+                pageSizes = [];
+                for (let p = 1; p <= totalPages; p++) {
+                    const vp = (await pdfDoc.getPage(p)).getViewport({scale: 1});
+                    pageSizes.push({width: vp.width, height: vp.height});
+                }
 
                 document.getElementById('no-preview').style.display = 'none';
                 document.getElementById('canvas-wrapper').style.display = 'block';
@@ -1465,11 +1521,85 @@
             }
         }
 
+        function goToPage(n) {
+            const target = Math.min(Math.max(parseInt(n, 10), 1), totalPages);
+            if (!Number.isFinite(target) || target === currentPage) {
+                updatePageNav();   // snap the input back to reality
+                return;
+            }
+            currentPage = target;
+            renderPage(currentPage);
+            updatePageNav();
+        }
+
+        function firstPage() { goToPage(1); }
+        function lastPage() { goToPage(totalPages); }
+
+        function commitPageInput() {
+            goToPage(document.getElementById('page-input').value);
+        }
+
         function updatePageNav() {
-            document.getElementById('page-num').textContent = currentPage;
+            document.getElementById('page-input').value = currentPage;
             document.getElementById('page-count').textContent = totalPages;
+            document.getElementById('first-btn').disabled = currentPage <= 1;
             document.getElementById('prev-btn').disabled = currentPage <= 1;
             document.getElementById('next-btn').disabled = currentPage >= totalPages;
+            document.getElementById('last-btn').disabled = currentPage >= totalPages;
+            updateAllPagesButton();
+        }
+
+        // Keep a box inside its target page. Mirrors clamp_box() in app.py; the
+        // backend re-clamps authoritatively, this is so the preview matches.
+        const BOX_MARGIN = 4;
+
+        function clampBoxToPage(box, pageSize) {
+            const maxX = pageSize.width - box.width - BOX_MARGIN;
+            const maxY = pageSize.height - box.height - BOX_MARGIN;
+            return {
+                x: maxX < BOX_MARGIN ? BOX_MARGIN : Math.min(Math.max(box.x, BOX_MARGIN), maxX),
+                y: maxY < BOX_MARGIN ? BOX_MARGIN : Math.min(Math.max(box.y, BOX_MARGIN), maxY),
+            };
+        }
+
+        function boxesOnCurrentPage() {
+            return (signatureBoxes[selectedFileIndex] || []).filter(b => b.page === currentPage);
+        }
+
+        function updateAllPagesButton() {
+            const btn = document.getElementById('all-pages-btn');
+            if (!btn) return;
+            btn.disabled = totalPages < 2 || boxesOnCurrentPage().length === 0;
+        }
+
+        function applyBoxToAllPages() {
+            const sources = boxesOnCurrentPage();
+            if (sources.length === 0 || totalPages < 2) return;
+
+            // The box the user drew stays first in the list - the backend treats
+            // index 0 as the one real signature field and the rest as stamps.
+            const kept = (signatureBoxes[selectedFileIndex] || [])
+                .filter(b => b.page === currentPage);
+            const replicated = [];
+
+            for (let p = 1; p <= totalPages; p++) {
+                if (p === currentPage) continue;
+                const size = pageSizes[p - 1];
+                sources.forEach(src => {
+                    const pos = size ? clampBoxToPage(src, size) : {x: src.x, y: src.y};
+                    replicated.push({
+                        page: p, x: pos.x, y: pos.y,
+                        width: src.width, height: src.height,
+                    });
+                });
+            }
+
+            signatureBoxes[selectedFileIndex] = kept.concat(replicated);
+            renderSignatureBoxes();
+            renderFileList();
+            updateSigBoxesInfo();
+            updateSignButton();
+            updatePageNav();
         }
 
         // Zoom
@@ -1487,6 +1617,7 @@
 
         function updateSigBoxesInfo() {
             const info = document.getElementById('sig-boxes-info');
+            updateAllPagesButton();
 
             if (files.length === 0) {
                 info.innerHTML = 'No files uploaded yet.';
@@ -1593,9 +1724,9 @@
 
             try {
                 const pkcs11Path = getPkcs11Path();
-                // Add client-side timeout (10 seconds) in case server hangs
+                // Add client-side timeout (30 seconds) — PKCS#11 slot enumeration can be slow
                 const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), 10000);
+                const timeoutId = setTimeout(() => controller.abort(), 30000);
 
                 const response = await fetch('/api/slots?pkcs11_path=' + encodeURIComponent(pkcs11Path), {
                     signal: controller.signal
@@ -1651,12 +1782,12 @@
 
         function startCardDetection() {
             detectCard();
-            // Poll every 5 seconds until card found
+            // Poll every 15 seconds until card found (slot query takes ~8s)
             cardDetectionInterval = setInterval(() => {
-                if (!cardFound) {
+                if (!cardFound && !isDetecting) {
                     detectCard();
                 }
-            }, 5000);
+            }, 15000);
         }
 
         // Wizard functions
@@ -1678,6 +1809,9 @@
             const downloadBtn = document.getElementById('download-btn');
             downloadBtn.disabled = false;
             downloadBtn.textContent = 'Download Signed Files';
+            downloadBtn.style.display = '';
+            const successIconReset = document.querySelector('#signing-complete .success-icon');
+            if (successIconReset) successIconReset.textContent = '✅';
 
             // Populate slot select and preselect slot 2 (signing slot) or first available
             const select = document.getElementById('slot-select');
@@ -1837,6 +1971,9 @@
             document.getElementById('signing-progress').style.display = 'none';
             document.getElementById('signing-complete').style.display = 'block';
 
+            const successIcon = document.querySelector('#signing-complete .success-icon');
+            const dlBtn = document.getElementById('download-btn');
+
             if (errors.length > 0) {
                 showWizardError(3, errors.join('\n'));
                 document.getElementById('complete-text').textContent =
@@ -1846,11 +1983,27 @@
                     `All ${signedFiles.length} document${signedFiles.length > 1 ? 's' : ''} signed successfully!`;
             }
 
+            // Nothing signed: don't show a success tick or offer a download that
+            // would only produce an empty archive.
+            if (signedFiles.length === 0) {
+                if (successIcon) successIcon.textContent = '❌';
+                dlBtn.style.display = 'none';
+            } else {
+                if (successIcon) successIcon.textContent = '✅';
+                dlBtn.style.display = '';
+            }
+
             updateSignButton();
         }
 
         async function downloadSignedFiles() {
             const btn = document.getElementById('download-btn');
+
+            if (signedFiles.length === 0) {
+                alert('No signed documents to save - all documents failed to sign.');
+                return;
+            }
+
             btn.disabled = true;
             btn.textContent = 'Saving...';
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -187,6 +187,65 @@
             flex: 1;
             overflow-y: auto;
             padding: 10px;
+            min-height: 0;   /* let the About panel keep its place when the list is long */
+        }
+
+        .about-panel {
+            flex-shrink: 0;
+            padding: 12px 15px 14px;
+            border-top: 1px solid rgba(255,255,255,0.1);
+            background: rgba(255,255,255,0.02);
+        }
+
+        .about-title {
+            font-size: 10px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: #00d4ff;
+            margin-bottom: 6px;
+        }
+
+        .about-name {
+            font-size: 13px;
+            font-weight: 600;
+            color: #e8e8f0;
+            margin-bottom: 8px;
+        }
+
+        .about-links {
+            display: flex;
+            flex-direction: column;
+            gap: 5px;
+        }
+
+        .about-links a {
+            display: flex;
+            align-items: center;
+            gap: 7px;
+            font-size: 11.5px;
+            color: #9a9aad;
+            text-decoration: none;
+            transition: color 0.2s;
+            min-width: 0;
+        }
+
+        /* Fixed box + currentColor keeps all four icons optically identical
+           and lets them pick up the hover colour. */
+        .about-icon {
+            width: 13px;
+            height: 13px;
+            flex-shrink: 0;
+            display: block;
+        }
+
+        .about-links a span {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .about-links a:hover {
+            color: #00d4ff;
         }
 
         .file-item {
@@ -913,6 +972,43 @@
             <div class="file-list" id="file-list">
                 <!-- Files will be listed here -->
             </div>
+            <div class="about-panel">
+                <div class="about-title">About</div>
+                <div class="about-name">Adrian B.</div>
+                <div class="about-links">
+                    <!-- Inline SVG rather than emoji: emoji render at wildly different
+                         sizes and force their own colour, so the row looked ragged. -->
+                    <a href="#" onclick="openExternal('email'); return false;" title="contact@plixco.ro">
+                        <svg class="about-icon" viewBox="0 0 16 16" aria-hidden="true">
+                            <rect x="1.2" y="3.2" width="13.6" height="9.6" rx="1.4"
+                                  fill="none" stroke="currentColor" stroke-width="1.4"/>
+                            <path d="M1.9 4.5 8 9l6.1-4.5" fill="none" stroke="currentColor"
+                                  stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                        <span>contact@plixco.ro</span>
+                    </a>
+                    <a href="#" onclick="openExternal('website'); return false;" title="https://plixco.ro">
+                        <svg class="about-icon" viewBox="0 0 16 16" aria-hidden="true">
+                            <circle cx="8" cy="8" r="6.3" fill="none" stroke="currentColor" stroke-width="1.4"/>
+                            <ellipse cx="8" cy="8" rx="2.7" ry="6.3" fill="none" stroke="currentColor" stroke-width="1.4"/>
+                            <path d="M2.1 5.9h11.8M2.1 10.1h11.8" fill="none" stroke="currentColor" stroke-width="1.4"/>
+                        </svg>
+                        <span>plixco.ro</span>
+                    </a>
+                    <a href="#" onclick="openExternal('github'); return false;" title="https://github.com/sudondream">
+                        <svg class="about-icon" viewBox="0 0 16 16" aria-hidden="true">
+                            <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.6 7.6 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/>
+                        </svg>
+                        <span>github.com/sudondream</span>
+                    </a>
+                    <a href="#" onclick="openExternal('linkedin'); return false;" title="https://www.linkedin.com/in/sudondream/">
+                        <svg class="about-icon" viewBox="0 0 16 16" aria-hidden="true">
+                            <path fill="currentColor" d="M3.6 5.9H1V15h2.6V5.9ZM2.3 1.2a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3ZM15 9.8c0-2.4-1.3-3.5-3-3.5-1.4 0-2 .77-2.35 1.3V5.9H7.05c.03.73 0 9.1 0 9.1h2.6V9.95c0-.23.02-.47.09-.64.19-.47.62-.95 1.34-.95.94 0 1.32.72 1.32 1.77V15H15V9.8Z"/>
+                        </svg>
+                        <span>linkedin.com/in/sudondream</span>
+                    </a>
+                </div>
+            </div>
         </div>
 
         <!-- Center Panel - Preview -->
@@ -1096,6 +1192,20 @@
 
         // Settings
         const DEFAULT_PKCS11_PATH = '/Library/Application Support/com.idemia.idplug/lib/libidplug-pkcs11.2.7.0.dylib';
+
+        // Open an About link in the real browser. A plain <a href> would make
+        // pywebview navigate the app window itself, replacing the signer UI.
+        async function openExternal(key) {
+            try {
+                await fetch('/api/open-external', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({key: key})
+                });
+            } catch (e) {
+                console.error('Could not open link:', e);
+            }
+        }
 
         function getPkcs11Path() {
             return localStorage.getItem('pkcs11_path') || DEFAULT_PKCS11_PATH;

--- a/test_app.py
+++ b/test_app.py
@@ -387,6 +387,62 @@ class StampAllPagesTests(unittest.TestCase):
             app_module.apply_visual_stamps(writer, reader, [], 2, 'X', 'Y'), 0)
 
 
+class OpenExternalTests(unittest.TestCase):
+    """About links must open in the real browser, and only known destinations.
+
+    pywebview navigates the app window itself on a normal link, which would
+    strand the user on an external page with no way back to the app.
+    """
+
+    def setUp(self):
+        app_module.app.config['TESTING'] = True
+        self.client = app_module.app.test_client()
+
+    def test_known_key_opens_the_right_url(self):
+        with mock.patch.object(app_module.subprocess, 'run') as run:
+            resp = self.client.post('/api/open-external', json={'key': 'github'})
+        self.assertEqual(resp.status_code, 200)
+        run.assert_called_once()
+        self.assertEqual(run.call_args[0][0],
+                         ['open', 'https://github.com/sudondream'])
+
+    def test_linkedin_opens_the_right_url(self):
+        with mock.patch.object(app_module.subprocess, 'run') as run:
+            resp = self.client.post('/api/open-external', json={'key': 'linkedin'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(run.call_args[0][0],
+                         ['open', 'https://www.linkedin.com/in/sudondream/'])
+
+    def test_every_about_link_is_reachable(self):
+        for key in ('website', 'github', 'linkedin', 'email'):
+            with mock.patch.object(app_module.subprocess, 'run') as run:
+                resp = self.client.post('/api/open-external', json={'key': key})
+            self.assertEqual(resp.status_code, 200, key)
+            run.assert_called_once()
+
+    def test_unknown_key_is_rejected_and_opens_nothing(self):
+        with mock.patch.object(app_module.subprocess, 'run') as run:
+            resp = self.client.post('/api/open-external', json={'key': 'nope'})
+        self.assertEqual(resp.status_code, 400)
+        run.assert_not_called()
+
+    def test_raw_url_cannot_be_injected(self):
+        # The frontend sends a key, never a URL, so this must not be usable as
+        # an arbitrary-URL or arbitrary-argument opener.
+        for hostile in ('https://evil.example.com', 'file:///etc/passwd',
+                        '/Applications/Calculator.app', '-a', ''):
+            with mock.patch.object(app_module.subprocess, 'run') as run:
+                resp = self.client.post('/api/open-external', json={'key': hostile})
+            self.assertEqual(resp.status_code, 400, hostile)
+            run.assert_not_called()
+
+    def test_missing_body_is_rejected(self):
+        with mock.patch.object(app_module.subprocess, 'run') as run:
+            resp = self.client.post('/api/open-external', json={})
+        self.assertEqual(resp.status_code, 400)
+        run.assert_not_called()
+
+
 class NoCtkKillTests(unittest.TestCase):
     """Killing CryptoTokenKit made the reader invisible to PC/SC until re-plug.
 

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Tests for the signing flow's non-card logic.
+
+Run: venv/bin/python test_app.py
+
+These cover the two defects that produced "0 of 3 signed, empty zip":
+  1. slot lookup took a single snapshot of a driver that enumerates slots
+     progressively, so slot 2 was often missing
+  2. /api/save-files turned an empty file list into an empty ZIP instead of
+     an error
+
+No smart card required.
+"""
+import os
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+import app as app_module
+
+
+class FakeSlot:
+    def __init__(self, slot_id):
+        self.slot_id = slot_id
+
+
+class FakeLib:
+    """Mimics the Idemia driver warming up: slot 2 only shows up after N calls."""
+
+    def __init__(self, sequence):
+        self.sequence = list(sequence)
+        self.calls = 0
+
+    def get_slots(self, token_present=True):
+        ids = self.sequence[min(self.calls, len(self.sequence) - 1)]
+        self.calls += 1
+        return [FakeSlot(i) for i in ids]
+
+
+class FindSlotTests(unittest.TestCase):
+    """find_slot must outlast the driver's progressive slot enumeration."""
+
+    def _clock(self):
+        """Deterministic fake clock; sleep advances it."""
+        state = {'t': 0.0}
+        return state, (lambda: state['t']), (lambda d: state.__setitem__('t', state['t'] + d))
+
+    def test_finds_slot_present_immediately(self):
+        lib = FakeLib([[1, 2, 3]])
+        state, now, sleep = self._clock()
+        slot, seen = app_module.find_slot(lib, 2, now=now, sleep=sleep)
+        self.assertIsNotNone(slot)
+        self.assertEqual(slot.slot_id, 2)
+        self.assertEqual(lib.calls, 1, "should not poll again once found")
+
+    def test_finds_slot_that_appears_late(self):
+        # Exactly what we measured: cold enumeration returns only slot 1.
+        lib = FakeLib([[1], [1], [1, 2, 3]])
+        state, now, sleep = self._clock()
+        slot, seen = app_module.find_slot(lib, 2, now=now, sleep=sleep)
+        self.assertIsNotNone(slot, "slot 2 appears on the 3rd enumeration; must keep polling")
+        self.assertEqual(slot.slot_id, 2)
+        self.assertEqual(seen, [1, 2, 3])
+
+    def test_gives_up_after_timeout_and_reports_what_it_saw(self):
+        lib = FakeLib([[1]])
+        state, now, sleep = self._clock()
+        slot, seen = app_module.find_slot(lib, 2, timeout=10, poll_interval=2,
+                                          now=now, sleep=sleep)
+        self.assertIsNone(slot)
+        self.assertEqual(seen, [1], "caller needs the observed slot IDs for the error message")
+        self.assertGreaterEqual(state['t'], 10, "must actually wait out the timeout")
+
+
+class SaveFilesTests(unittest.TestCase):
+    """/api/save-files must refuse an empty list instead of writing an empty ZIP."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        app_module.app.config['TESTING'] = True
+        self.client = app_module.app.test_client()
+        # Never touch the real ~/Downloads, and never pop Finder open.
+        patcher = mock.patch.object(app_module, 'DOWNLOADS_FOLDER', self.tmp)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        reveal = mock.patch.object(app_module, 'reveal_in_finder')
+        reveal.start()
+        self.addCleanup(reveal.stop)
+
+    def test_empty_file_list_is_an_error_not_an_empty_zip(self):
+        resp = self.client.post('/api/save-files', json={'files': []})
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('error', resp.get_json())
+        self.assertEqual(os.listdir(self.tmp), [],
+                         "nothing should be written to Downloads when there is nothing to save")
+
+    def test_multiple_files_still_zip(self):
+        import base64
+        payload = {'files': [
+            {'name': 'a.pdf', 'data': base64.b64encode(b'aaa').decode()},
+            {'name': 'b.pdf', 'data': base64.b64encode(b'bbb').decode()},
+        ]}
+        resp = self.client.post('/api/save-files', json=payload)
+        self.assertEqual(resp.status_code, 200)
+        zips = [f for f in os.listdir(self.tmp) if f.endswith('.zip')]
+        self.assertEqual(len(zips), 1)
+        with zipfile.ZipFile(os.path.join(self.tmp, zips[0])) as zf:
+            self.assertEqual(sorted(zf.namelist()), ['a.pdf', 'b.pdf'])
+
+    def test_single_file_saved_directly(self):
+        import base64
+        payload = {'files': [{'name': 'solo.pdf', 'data': base64.b64encode(b'xyz').decode()}]}
+        resp = self.client.post('/api/save-files', json=payload)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(os.listdir(self.tmp), ['solo.pdf'])
+
+
+class FakeToken:
+    def __init__(self, label):
+        self.label = label
+
+
+class LabelledSlot:
+    def __init__(self, slot_id, label):
+        self.slot_id = slot_id
+        self._label = label
+
+    def get_token(self):
+        return FakeToken(self._label)
+
+
+class LabelledLib:
+    def __init__(self, sequence):
+        self.sequence = list(sequence)
+        self.calls = 0
+
+    def get_slots(self, token_present=True):
+        entry = self.sequence[min(self.calls, len(self.sequence) - 1)]
+        self.calls += 1
+        return [LabelledSlot(i, f'token-{i}') for i in entry]
+
+
+class EnumerateSlotsTests(unittest.TestCase):
+    """/api/slots must report the card's real slots, not a hardcoded 1/2/3."""
+
+    def _clock(self):
+        state = {'t': 0.0}
+        return state, (lambda: state['t']), (lambda d: state.__setitem__('t', state['t'] + d))
+
+    def test_waits_for_progressive_enumeration(self):
+        # Driver reveals slots over time, then settles.
+        lib = LabelledLib([[1], [1, 2], [1, 2, 3], [1, 2, 3], [1, 2, 3]])
+        _, now, sleep = self._clock()
+        slots = app_module.enumerate_slots(lib, now=now, sleep=sleep)
+        self.assertEqual([s['id'] for s in slots], [1, 2, 3])
+        self.assertEqual(slots[1]['label'], 'token-2')
+
+    def test_keeps_union_when_driver_drops_a_slot(self):
+        # Observed for real: [1,2,3] on one read, [1,2] on the next.
+        lib = LabelledLib([[1, 2, 3], [1, 2], [1, 2]])
+        _, now, sleep = self._clock()
+        slots = app_module.enumerate_slots(lib, now=now, sleep=sleep)
+        self.assertEqual([s['id'] for s in slots], [1, 2, 3],
+                         "a slot vanishing between reads must not un-list it")
+
+    def test_returns_empty_when_no_slots_ever_appear(self):
+        lib = LabelledLib([[]])
+        _, now, sleep = self._clock()
+        slots = app_module.enumerate_slots(lib, settle_timeout=10, poll_interval=2,
+                                           now=now, sleep=sleep)
+        self.assertEqual(slots, [])
+
+    def test_no_hardcoded_slot_labels_in_source(self):
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'app.py')) as fh:
+            src = fh.read()
+        for needle in ("'PKI User PIN (Authentication)'",
+                       "'ADVANCED SIGNATURE PIN (Signing)'",
+                       "'QSCD PIN'"):
+            self.assertFalse(needle in src,
+                             f"slot list must come from the card, not the literal {needle}")
+
+
+class SlotsEndpointTests(unittest.TestCase):
+    def setUp(self):
+        app_module.app.config['TESTING'] = True
+        self.client = app_module.app.test_client()
+        app_module.clear_slot_cache()
+        self.addCleanup(app_module.clear_slot_cache)
+
+    def test_no_card_reports_absence_and_clears_cache(self):
+        app_module._slot_cache['x'] = [{'id': 1}]
+        with mock.patch.object(app_module, 'detect_reader', return_value=(None, False)):
+            resp = self.client.get('/api/slots')
+        self.assertEqual(resp.get_json()['slots'], [])
+        self.assertEqual(app_module._slot_cache, {}, "cache must drop when the card leaves")
+
+    def test_card_present_returns_enumerated_slots_and_caches(self):
+        enum = mock.Mock(return_value=[{'id': 2, 'label': 'ADVANCED SIGNATURE PIN'}])
+        with mock.patch.object(app_module, 'detect_reader', return_value=('Reader X', True)), \
+             mock.patch.object(app_module, 'enumerate_slots', enum), \
+             mock.patch.object(app_module.pkcs11, 'lib', mock.Mock()):
+            first = self.client.get('/api/slots').get_json()
+            second = self.client.get('/api/slots').get_json()
+
+        self.assertEqual([s['id'] for s in first['slots']], [2])
+        self.assertEqual(first['slots'][0]['model'], 'Reader X')
+        self.assertEqual(first, second)
+        self.assertEqual(enum.call_count, 1, "second poll must be served from cache")
+
+
+def build_nested_page_tree_pdf():
+    """Minimal PDF whose /Pages/Kids is a TREE, not a flat page list.
+
+    Root /Pages has a single intermediate /Pages kid holding the 2 real pages,
+    and /MediaBox lives only on the root - so the pages inherit it. Both traits
+    are present in the user's real documents and both broke the old code.
+    """
+    objs = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 2 /MediaBox [0 0 595.2 841.92] >>",
+        b"<< /Type /Pages /Parent 2 0 R /Kids [4 0 R 5 0 R] /Count 2 >>",
+        b"<< /Type /Page /Parent 3 0 R /Resources << >> >>",
+        b"<< /Type /Page /Parent 3 0 R /Resources << >> >>",
+    ]
+    out = bytearray(b"%PDF-1.7\n")
+    offsets = []
+    for i, body in enumerate(objs, start=1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n" % i + body + b"\nendobj\n"
+
+    xref_at = len(out)
+    out += b"xref\n0 %d\n" % (len(objs) + 1)
+    out += b"0000000000 65535 f \n"
+    for off in offsets:
+        out += b"%010d 00000 n \n" % off
+    out += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (
+        len(objs) + 1, xref_at)
+    return bytes(out)
+
+
+class PageTreeTests(unittest.TestCase):
+    """/Pages/Kids is a tree; indexing it by page number is wrong."""
+
+    def setUp(self):
+        from io import BytesIO
+        from pyhanko.pdf_utils.reader import PdfFileReader
+        self.reader = PdfFileReader(BytesIO(build_nested_page_tree_pdf()), strict=False)
+
+    def test_flat_kids_indexing_is_the_bug(self):
+        # Guards the premise: 2 pages, but only 1 entry in the root's /Kids.
+        kids = self.reader.root['/Pages']['/Kids']
+        self.assertEqual(len(kids), 1)
+        self.assertEqual(int(self.reader.root['/Pages']['/Count']), 2)
+        with self.assertRaises(IndexError):
+            kids[1]
+
+    def test_media_box_found_for_last_page_via_tree_walk(self):
+        box = app_module.get_page_media_box(self.reader, 1)
+        self.assertEqual([round(v, 2) for v in box], [0.0, 0.0, 595.2, 841.92])
+
+    def test_media_box_is_inherited_not_defaulted_to_letter(self):
+        box = app_module.get_page_media_box(self.reader, 0)
+        self.assertNotEqual([round(v) for v in box], [0, 0, 612, 792],
+                            "must inherit A4 from the parent, not fall back to Letter")
+
+    def test_out_of_range_page_raises(self):
+        from pyhanko.pdf_utils.misc import PdfError
+        with self.assertRaises(PdfError):
+            app_module.get_page_media_box(self.reader, 5)
+
+
+A4 = [0.0, 0.0, 595.2, 841.92]
+A4_LANDSCAPE = [0.0, 0.0, 841.92, 595.2]
+
+
+class ClampBoxTests(unittest.TestCase):
+    """Same spot when it fits; slid inside the page when it doesn't."""
+
+    def test_box_that_fits_is_untouched(self):
+        x, y = app_module.clamp_box(400, 100, 150, 70, A4)
+        self.assertEqual((x, y), (400, 100))
+
+    def test_box_overflowing_top_slides_down(self):
+        # y is the lower-left corner; 800 + 70 > 841.92
+        x, y = app_module.clamp_box(400, 800, 150, 70, A4)
+        self.assertEqual(x, 400)
+        self.assertAlmostEqual(y, 841.92 - 70 - app_module.BOX_MARGIN, places=2)
+
+    def test_box_overflowing_right_slides_left(self):
+        x, y = app_module.clamp_box(700, 100, 150, 70, A4)
+        self.assertAlmostEqual(x, 595.2 - 150 - app_module.BOX_MARGIN, places=2)
+        self.assertEqual(y, 100)
+
+    def test_negative_coords_pushed_to_margin(self):
+        x, y = app_module.clamp_box(-50, -50, 150, 70, A4)
+        self.assertEqual((x, y), (app_module.BOX_MARGIN, app_module.BOX_MARGIN))
+
+    def test_landscape_page(self):
+        # x=600 overflows A4 portrait (600+150 > 595.2) but fits landscape.
+        x, _ = app_module.clamp_box(600, 100, 150, 70, A4)
+        self.assertAlmostEqual(x, 595.2 - 150 - app_module.BOX_MARGIN, places=2)
+        x, y = app_module.clamp_box(600, 100, 150, 70, A4_LANDSCAPE)
+        self.assertEqual((x, y), (600, 100))
+
+    def test_box_larger_than_page_pins_at_margin(self):
+        x, y = app_module.clamp_box(10, 10, 5000, 5000, A4)
+        self.assertEqual((x, y), (app_module.BOX_MARGIN, app_module.BOX_MARGIN),
+                         "an oversized box must not be pushed to negative coords")
+
+    def test_honours_nonzero_media_box_origin(self):
+        offset = [100.0, 200.0, 695.2, 1041.92]
+        x, y = app_module.clamp_box(0, 0, 150, 70, offset)
+        self.assertEqual((x, y), (100 + app_module.BOX_MARGIN, 200 + app_module.BOX_MARGIN))
+
+
+class ResolveBoxTests(unittest.TestCase):
+    """Frontend box (top-left origin) -> PDF box (bottom-left origin), clamped."""
+
+    def setUp(self):
+        from io import BytesIO
+        from pyhanko.pdf_utils.reader import PdfFileReader
+        self.reader = PdfFileReader(BytesIO(build_nested_page_tree_pdf()), strict=False)
+
+    def test_flips_y_axis(self):
+        box = {'page': 1, 'x': 100, 'y': 50, 'width': 150, 'height': 70}
+        page_ix, x, y, w, h = app_module.resolve_box(self.reader, box, 2)
+        self.assertEqual(page_ix, 0)
+        self.assertEqual(x, 100)
+        # top-left y=50 with height 70 -> lower-left y = 841.92 - 50 - 70
+        self.assertAlmostEqual(y, 841.92 - 50 - 70, places=2)
+        self.assertEqual((w, h), (150, 70))
+
+    def test_second_page_resolves_via_tree(self):
+        box = {'page': 2, 'x': 10, 'y': 10, 'width': 50, 'height': 20}
+        page_ix, x, y, w, h = app_module.resolve_box(self.reader, box, 2)
+        self.assertEqual(page_ix, 1)
+
+    def test_page_out_of_range_rejected(self):
+        box = {'page': 9, 'x': 10, 'y': 10, 'width': 50, 'height': 20}
+        with self.assertRaises(ValueError):
+            app_module.resolve_box(self.reader, box, 2)
+
+
+class ExistingSignatureTests(unittest.TestCase):
+    def test_unsigned_document_reports_false(self):
+        from io import BytesIO
+        from pyhanko.pdf_utils.reader import PdfFileReader
+        reader = PdfFileReader(BytesIO(build_nested_page_tree_pdf()), strict=False)
+        self.assertFalse(app_module.document_has_signature(reader))
+
+
+class StampAllPagesTests(unittest.TestCase):
+    """Extra boxes must become real page content, not be silently dropped."""
+
+    def test_stamps_are_applied_to_every_listed_page(self):
+        from io import BytesIO
+        from pyhanko.pdf_utils.reader import PdfFileReader
+        from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+
+        reader = PdfFileReader(BytesIO(build_nested_page_tree_pdf()), strict=False)
+        writer = IncrementalPdfFileWriter.from_reader(reader)
+
+        boxes = [
+            {'page': 1, 'x': 100, 'y': 50, 'width': 150, 'height': 70},
+            {'page': 2, 'x': 100, 'y': 50, 'width': 150, 'height': 70},
+        ]
+        # box 0 is the real signature field; box 1 becomes a stamp
+        applied = app_module.apply_visual_stamps(writer, reader, boxes[1:], 2,
+                                                 'ADRIAN BANCU', '2026-08-06 12:00')
+        self.assertEqual(applied, 1)
+
+        out = BytesIO()
+        writer.write(out)
+        signed = PdfFileReader(BytesIO(out.getvalue()), strict=False)
+        page_ref, _ = signed.find_page_for_modification(1)
+        self.assertIn('/Contents', page_ref.get_object(),
+                      "stamped page must carry a content stream")
+
+    def test_no_extra_boxes_is_a_noop(self):
+        from io import BytesIO
+        from pyhanko.pdf_utils.reader import PdfFileReader
+        from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+        reader = PdfFileReader(BytesIO(build_nested_page_tree_pdf()), strict=False)
+        writer = IncrementalPdfFileWriter.from_reader(reader)
+        self.assertEqual(
+            app_module.apply_visual_stamps(writer, reader, [], 2, 'X', 'Y'), 0)
+
+
+class NoCtkKillTests(unittest.TestCase):
+    """Killing CryptoTokenKit made the reader invisible to PC/SC until re-plug.
+
+    PKCS#11 works fine alongside CTK, so the kill must be gone for good.
+    """
+
+    def test_kill_ctkd_no_longer_exists(self):
+        self.assertFalse(hasattr(app_module, 'kill_ctkd'),
+                         "kill_ctkd tears down ctkpcscd and blinds the reader; it must not come back")
+
+    def test_source_has_no_ctk_pkill(self):
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'app.py')) as fh:
+            src = fh.read()
+        for needle in ('pkill', 'ctkd', 'ctkahp', 'with administrator privileges'):
+            self.assertFalse(needle in src, f"app.py must not reference {needle!r}")
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test_app.py
+++ b/test_app.py
@@ -454,10 +454,16 @@ class NoCtkKillTests(unittest.TestCase):
                          "kill_ctkd tears down ctkpcscd and blinds the reader; it must not come back")
 
     def test_source_has_no_ctk_pkill(self):
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'app.py')) as fh:
-            src = fh.read()
-        for needle in ('pkill', 'ctkd', 'ctkahp', 'with administrator privileges'):
-            self.assertFalse(needle in src, f"app.py must not reference {needle!r}")
+        # main.py is checked too: it is what launches the app, and a stale
+        # "Kill CTK, start Flask" docstring survived there once already.
+        here = os.path.dirname(os.path.abspath(__file__))
+        for filename in ('app.py', 'main.py'):
+            with open(os.path.join(here, filename)) as fh:
+                src = fh.read()
+            for needle in ('pkill', 'ctkd', 'ctkahp', 'Kill CTK',
+                           'with administrator privileges'):
+                self.assertFalse(needle in src,
+                                 f"{filename} must not reference {needle!r}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Signing failed for all three test documents — zero files signed and an empty ZIP. This fixes the causes, then adds the page features requested on top.

## The signing failure

Three independent causes, each verified against the real card and the real documents.

**1. Killing CryptoTokenKit destroyed reader access.** `kill_ctkd()` ran `pkill -9 ctkd; pkill -9 ctkahp` with administrator privileges at the start of *every* `/api/sign` call. Killing `ctkd` takes `ctkpcscd` down with it — the XPC child that actually provides PC/SC — so the reader went invisible to every tool while still enumerated on USB, recoverable only by physically re-plugging it.

It was also unnecessary. Measured with all CryptoTokenKit daemons alive and untouched:

```
pkcs11.lib()                0.2s
get_slots()                 2-19s
certificate read            works
opensc-tool after the call  reader still visible — no PC/SC poisoning
```

`LESSONS_LEARNED.md` had asserted the opposite, and that false premise is what put `kill_ctkd()` into the signing path. Corrected, with a test that fails the build if any CTK-killing code returns.

**2. Slot enumeration is progressive, not atomic.** The IdPlug driver discovers the card's applications lazily — across runs it returned `[1]`, `[1]`, `[1,2,3]`, then `[1,2]`. The old code took one snapshot and gave up. `find_slot()` now polls; slot 2 took 12.3s and several enumerations to appear on a warm reader.

`/api/slots` also stopped inventing a hardcoded 1/2/3 list and reports the card's real slots and labels, cached per library path (12.5s cold → 0.03s warm), dropped when the card is removed.

**3. `/Pages/Kids` is a tree, not a flat page list.** Indexing it by page number raised `IndexError` on any document with an intermediate `/Pages` node:

| file | pages | `len(/Kids)` | old code failed on |
|---|---|---|---|
| 01_Raspuns_la_intampinare | 10 | 2 | 8 of 10 pages |
| 02_Anexa_1_Preturi | 12 | 2 | 10 of 12 pages |
| 03_Anexa_2_Panou | 6 | 6 | 0 (flat — worked by luck) |

Now uses pyHanko's `find_page_for_modification()`. The same line had a silent bug too: `/MediaBox` is inheritable, so the old US-Letter fallback misplaced signatures by ~50pt on A4 without ever erroring.

Plus: `/api/save-files` reported success for an empty list by writing a zero-entry ZIP. Now returns 400, and the UI no longer shows a success tick or download button when nothing was signed.

## Features

**Page navigation** — page-number input plus first/last buttons; invalid input snaps back.

**Apply to all pages** — copies the current page's signature box to every page, clamped against each page's real geometry. Clamping runs client-side too, so the preview matches the output exactly.

The backend previously used `signature_boxes[0]` and **silently discarded the rest**, so boxes drawn on other pages never appeared. Box 0 is now the real signature field; the rest become visual stamps applied before `sign_pdf()`, so one qualified signature covers them all:

| file | pages | stamps | AcroForm fields |
|---|---|---|---|
| 01 | 10 | 9 | **1** |
| 02 | 12 | 11 | **1** |
| 03 | 6 | 5 | **1** |

Chose one signature plus visual marks over a real signature field per page: the latter would cost one PKCS#11 operation and one incremental update per page, show 12 signatures on a 12-page document, and amount to signing the same document 12 times. Rationale in the spec.

Also guards a blank page with no `/Contents` (made pyHanko's `add_stream_to_page` raise `KeyError`) and refuses to stamp a document already carrying someone else's signature, since that would invalidate it.

**Clear all** — removes every signature box from the selected document. Apply-to-all can create a dozen boxes and removing them meant clicking each delete handle, page by page. Shows the count and confirms when clearing more than one.

**About section** — always visible at the bottom of the left sidebar: name, email, website, GitHub, LinkedIn.

Links go through `/api/open-external` rather than being plain anchors, because pywebview follows a normal link *in the app window* and would replace the signer UI with the target page. That endpoint takes a **key**, never a URL — destinations live server-side in `ABOUT_LINKS` — so it cannot become an arbitrary-URL or arbitrary-argument opener. Tests cover rejection of raw URLs, `file://` paths, app paths, bare flags and empty input.

Icons are inline SVG in a fixed 13×13 box using `currentColor`. The first cut mixed emoji with text glyphs, which rendered at visibly different sizes and forced their own colours.

## Housekeeping

- Merged `main` in, picking up the IDPlugManager link fix from #3. Without it this branch would have carried the dead `inteligent.ro` link forward.
- GitHub account renamed, so all references moved from `github.com/BancuTheKind/...` to `github.com/sudondream/...` and `bancuthekind.github.io` to `sudondream.github.io` — the Pages URL is derived from the username. Old URLs still redirect; the explicit ones are correct.

## Docs

README troubleshooting led with a persistent system-wide `defaults write ... allowSmartCard -bool false`. Re-plugging the reader now leads, with an explicit warning never to `pkill` CryptoTokenKit, and a note that slow first detection is normal warm-up. Both EN and RO. Feature lists updated, and a "Sign Every Page" card added to the Pages site.

## Testing

37 tests, stdlib `unittest`, no new dependencies. Covers clamping geometry, page-tree walking and MediaBox inheritance (via a synthetic PDF built with both traits), slot enumeration and caching, save-files behaviour, the external-link allowlist, and regression guards against the CTK kill and the hardcoded slot labels.

**Verified end to end on the real card:** all three documents signed successfully after the fixes.

**Not verified:** the *rendered* placement of the all-pages stamps. Field and stamp counts and positions are confirmed structurally against the real documents, but nobody has looked at the output on screen. Worth checking before merge.

Known gap: `/Rotate` is inheritable and is not accounted for, so placement on a rotated page would be wrong. None of the test documents are rotated; noted in `LESSONS_LEARNED.md`.

https://claude.ai/code/session_016UCBAStnuuJJvx3mHKxQ9V
