### PR TITLE
Drop PyKCS11: nothing has called it since the python-pkcs11 switch

### DIFF
--- a/CEIPDFSigner.spec
+++ b/CEIPDFSigner.spec
@@ -28,7 +28,6 @@ a = Analysis(
         'werkzeug',
         'jinja2',
         'jinja2.ext',
-        'PyKCS11',
         'pyhanko',
         'pyhanko.sign',
         'pyhanko.sign.signers',

--- a/LESSONS_LEARNED.md
+++ b/LESSONS_LEARNED.md
@@ -23,6 +23,10 @@
 - The old note "(This may not apply to python-pkcs11)" was the correct instinct. It doesn't.
 - PyKCS11 may still hang — untested since the switch to `python-pkcs11`. Do not
   generalize from it back to `python-pkcs11`.
+- **PyKCS11 was removed entirely on 2026-08-06.** No code had called it since the
+  switch; it survived only as an unused import, a `/api/status` flag and a bundled
+  dependency. Everything card-facing goes through `python-pkcs11`. A test fails the
+  build if it is imported or listed as a dependency again.
 
 ### Slot Enumeration Is Progressive and Nondeterministic
 - The Idemia driver discovers the card's applications **lazily**. Successive runs returned:
@@ -104,7 +108,7 @@
   - Slot 2: `ADVANCED SIGNATURE PIN` (Qualified Electronic Signature)
   - Slot 3: `QSCD PIN` (Qualified Signature Creation Device)
 - Slot enumeration (`get_slots()`) takes ~7.5 seconds even when it works.
-- **The Idemia PKCS#11 library poisons the PC/SC connection**: after any call to it via PyKCS11, even `opensc-tool` stops seeing the reader until re-plug. (This may not apply to python-pkcs11.)
+- **The Idemia PKCS#11 library poisons the PC/SC connection**: after any call to it via PyKCS11, even `opensc-tool` stops seeing the reader until re-plug. (Historical — observed via PyKCS11, which is no longer a dependency. Measured *not* to happen with python-pkcs11; see the correction above.)
 
 ### Card File Structure
 - **Not standard PKCS#15** — `pkcs15-tool` returns "Card is invalid or cannot be handled".
@@ -197,7 +201,7 @@
 ### What Doesn't Work (with CTK active)
 | Tool/Library | Level | Issue |
 |---|---|---|
-| PyKCS11 | PKCS#11 | Hangs indefinitely (unverified since the switch away from it) |
+| ~~PyKCS11~~ | PKCS#11 | Hung indefinitely. **Removed as a dependency 2026-08-06** — nothing called it |
 | ~~python-pkcs11~~ | PKCS#11 | **Corrected 2026-08-06: works fine with CTK alive.** Slot enum is slow/progressive, not blocked |
 | `pkcs11-tool` | PKCS#11 | Hangs indefinitely |
 | `pkcs15-tool` | OpenSC/PC/SC | "Card is invalid" (proprietary card) |

--- a/app.py
+++ b/app.py
@@ -19,14 +19,15 @@ from flask import Flask, render_template, request, jsonify, send_file
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
 
-# PKCS#11 imports
+# PKCS#11 imports - python-pkcs11 talks to the card. PyKCS11 used to sit here
+# too; it is gone. Nothing called it after the switch, and its wildcard import
+# dumped ~200 CK* constants into this module's namespace.
 try:
-    import PyKCS11
-    from PyKCS11 import *
+    import pkcs11
     PKCS11_AVAILABLE = True
 except ImportError:
     PKCS11_AVAILABLE = False
-    print("Warning: PyKCS11 not installed. Install with: pip install PyKCS11")
+    print("Warning: python-pkcs11 not installed. Install with: pip install 'pyhanko[pkcs11]'")
 
 # PDF signing imports - using pyHanko for proper PKCS#11 ECDSA support
 try:
@@ -37,8 +38,6 @@ try:
     from pyhanko.stamp import TextStampStyle
     from pyhanko.pdf_utils.text import TextBoxStyle
     from pyhanko.pdf_utils.content import RawContent
-    import pkcs11
-    from pkcs11 import Mechanism
     PYHANKO_AVAILABLE = True
 except ImportError:
     PYHANKO_AVAILABLE = False
@@ -415,7 +414,7 @@ def api_slots():
         clear_slot_cache()
         return jsonify({'slots': [], 'error': 'No smart card detected. Please insert your CEI card.'})
 
-    if not PYHANKO_AVAILABLE:
+    if not PKCS11_AVAILABLE:
         return jsonify({'slots': [], 'error': 'python-pkcs11 not installed'})
 
     lib_path = get_pkcs11_lib_path(request.args.get('pkcs11_path'))
@@ -448,7 +447,7 @@ def api_slots():
 @app.route('/api/certificate', methods=['POST'])
 def api_get_certificate():
     """Get certificate from smart card using python-pkcs11"""
-    if not PYHANKO_AVAILABLE:
+    if not PKCS11_AVAILABLE:
         return jsonify({'error': 'python-pkcs11 not installed'}), 500
 
     data = request.json
@@ -529,8 +528,12 @@ def api_get_certificate():
 @app.route('/api/sign', methods=['POST'])
 def api_sign_pdf():
     """Sign a PDF document using pyHanko with PKCS#11"""
+    # Signing is the one path that needs both: pyHanko builds the PDF, and
+    # python-pkcs11 drives the card that produces the signature.
     if not PYHANKO_AVAILABLE:
         return jsonify({'error': 'pyHanko not installed'}), 500
+    if not PKCS11_AVAILABLE:
+        return jsonify({'error': 'python-pkcs11 not installed'}), 500
 
     # Get form data
     if 'pdf' not in request.files:
@@ -827,7 +830,7 @@ if __name__ == '__main__':
     print("CEI Web PDF Signer")
     print("="*60)
     print(f"\nPKCS#11 library: {get_pkcs11_lib_path()}")
-    print(f"PyKCS11 available: {PKCS11_AVAILABLE}")
+    print(f"python-pkcs11 available: {PKCS11_AVAILABLE}")
     print(f"pyHanko available: {PYHANKO_AVAILABLE}")
     print("\nOpen your browser and go to: http://localhost:5001")
     print("="*60 + "\n")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Flask>=2.3.0
 flask-cors>=4.0.0
-PyKCS11>=1.5.12
 pyhanko>=0.20.0
 pyhanko[pkcs11]
 cryptography>=41.0.0

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ OPTIONS = {
         'flask_cors',
         'werkzeug',
         'jinja2',
-        'PyKCS11',
         'pyhanko',
         'pyhanko.sign',
         'pyhanko.pdf_utils',

--- a/test_app.py
+++ b/test_app.py
@@ -12,6 +12,7 @@ These cover the two defects that produced "0 of 3 signed, empty zip":
 No smart card required.
 """
 import os
+import re
 import tempfile
 import unittest
 import zipfile
@@ -464,6 +465,56 @@ class NoCtkKillTests(unittest.TestCase):
                            'with administrator privileges'):
                 self.assertFalse(needle in src,
                                  f"{filename} must not reference {needle!r}")
+
+
+class NoPyKCS11Tests(unittest.TestCase):
+    """PyKCS11 was replaced by python-pkcs11 and must not creep back.
+
+    It hung on the Idemia driver, and a wildcard `from PyKCS11 import *`
+    dumps ~200 CK* names into module scope where they can shadow anything.
+    Shipping it also means bundling a dependency nothing calls.
+    """
+
+    SOURCES = ('app.py', 'main.py', 'setup.py', 'CEIPDFSigner.spec', 'requirements.txt')
+
+    # Matches importing it or listing it as a dependency, not merely naming it -
+    # the comment in app.py explaining why it was dropped has to stay legal.
+    REINTRODUCED = re.compile(
+        r'^\s*(?:import\s+PyKCS11|from\s+PyKCS11\b|["\']PyKCS11["\'],?|PyKCS11\s*[><=])',
+        re.MULTILINE,
+    )
+
+    def test_no_source_imports_or_ships_pykcs11(self):
+        here = os.path.dirname(os.path.abspath(__file__))
+        for filename in self.SOURCES:
+            with open(os.path.join(here, filename)) as fh:
+                src = fh.read()
+            hit = self.REINTRODUCED.search(src)
+            self.assertIsNone(hit,
+                              f"{filename} imports or ships PyKCS11 ({hit.group(0).strip()!r} "
+                              f"at char {hit.start()}); the card is driven by python-pkcs11"
+                              if hit else '')
+
+    def test_wildcard_import_did_not_leak_ck_constants(self):
+        """`from PyKCS11 import *` dumped every CK* name into app's namespace.
+
+        Checked separately from the source scan because this is the concrete
+        harm: ~200 unqualified constants able to shadow module-level names.
+        """
+        for leaked in ('CKA_CLASS', 'CKO_CERTIFICATE', 'CKF_SERIAL_SESSION'):
+            self.assertFalse(hasattr(app_module, leaked),
+                             f"{leaked} leaked into app.py via a wildcard import")
+
+    def test_status_reports_the_library_actually_used(self):
+        """pkcs11_available must track python-pkcs11, not the dropped binding.
+
+        The frontend gates its "dependencies missing" warning on this flag, so
+        pointing it at an unused library warns about the wrong thing.
+        """
+        client = app_module.app.test_client()
+        payload = client.get('/api/status').get_json()
+        self.assertTrue(payload['pkcs11_available'],
+                        "python-pkcs11 is importable, so the flag must be True")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow-up to #8, which left PyKCS11 behind as dead weight.

Slots, certificates and signing all go through `python-pkcs11`. PyKCS11 survived only as an unused import, a status flag, and a bundled dependency — shipped in the `.app`, pinned in `requirements.txt`, and never called.

## It wasn't inert

`from PyKCS11 import *` dumped ~200 unqualified `CK*` constants into `app.py`'s namespace, where any of them could shadow a module-level name.

## The status flag was misleading

`pkcs11_available` reported whether **PyKCS11** imported, and `templates/index.html:2224` gates its "Server dependencies missing" warning on it — so it warned about a library the app no longer uses. `pkcs11` now gets its own import block, so the flag means python-pkcs11, which is what the frontend actually wants to know.

That split also fixes gates that were already wrong:

| endpoint | checked | reported | uses |
|---|---|---|---|
| `/api/slots` | `PYHANKO_AVAILABLE` | "python-pkcs11 not installed" | pkcs11 |
| `/api/certificate` | `PYHANKO_AVAILABLE` | "python-pkcs11 not installed" | pkcs11 |
| `/api/sign` | `PYHANKO_AVAILABLE` | "pyHanko not installed" | both |

Each now checks what it uses; `/api/sign` checks both.

Also removes `from pkcs11 import Mechanism`, imported and never used.

## Verification

Imported `app.py` with PyKCS11 made unimportable through a `meta_path` blocker — it loads, `PKCS11_AVAILABLE` is `True`, `/api/status` is correct, and all 40 tests pass under the same block. (The first version of that blocker used the pre-3.12 `find_module` protocol and silently wasn't blocking anything; fixed to `find_spec` before trusting the result.)

A new guard fails the build if PyKCS11 is imported or listed as a dependency in `app.py`, `main.py`, `setup.py`, `CEIPDFSigner.spec` or `requirements.txt`. It matches imports and dependency pins rather than any mention, so the comment explaining the removal stays legal — confirmed it still fires for both a `requirements.txt` pin and a `setup.py` entry.

`LESSONS_LEARNED.md` keeps the historical PyKCS11 findings but marks it removed, so the "hangs indefinitely" note isn't read as describing a current dependency.

40 tests, all passing.

https://claude.ai/code/session_01GZ6eGpZMQjte2At4rdswC9