### PR TITLE
Fix release packaging so the shipped .app actually launches

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -27,10 +27,29 @@ ZIP_NAME="CEI-PDF-Signer-${VERSION}-macOS.zip"
 echo ""
 echo "Creez arhiva pentru release..."
 
-# Creeaza ZIP-ul cu aplicatia
-cd dist
-zip -r -y "../$RELEASE_DIR/$ZIP_NAME" "CEI PDF Signer.app"
-cd ..
+# IMPORTANT: se foloseste `ditto`, NU `zip`.
+#
+# Bundle-ul .app contine ~45 de symlink-uri (ex. Contents/Frameworks/python3.14
+# -> python3__dot__14) si depinde de bitii de executie POSIX. Orice arhivator
+# care nu le pastreaza distruge aplicatia in mod silentios: utilizatorul
+# primeste "The application can't be opened." sau
+# "ModuleNotFoundError: No module named '_struct'" (issues #4, #6, #7).
+#
+# `ditto -c -k --sequesterRsrc --keepParent` este metoda suportata de Apple
+# pentru arhivarea bundle-urilor si pastreaza symlink-uri, permisiuni si
+# atribute extinse. NU inlocui cu `zip`, `python -m zipfile` sau
+# "Compress" din alte platforme.
+ditto -c -k --sequesterRsrc --keepParent \
+    "dist/CEI PDF Signer.app" \
+    "$RELEASE_DIR/$ZIP_NAME"
+
+# Verifica arhiva rezultata inainte de a o publica. Fara acest pas,
+# o arhiva stricata ajunge in Releases si aplicatia nu porneste pe
+# niciun calculator in afara celui pe care s-a facut build-ul.
+echo ""
+./scripts/verify-release-archive.sh \
+    "$RELEASE_DIR/$ZIP_NAME" \
+    "dist/CEI PDF Signer.app"
 
 # Calculeaza SHA256
 echo ""
@@ -51,8 +70,9 @@ echo "SHA256: $SHA256"
 echo ""
 echo "Pentru a publica pe GitHub:"
 echo "  1. git push origin main --tags"
-echo "  2. Mergi la https://github.com/USERNAME/cei-web-signer/releases"
-echo "  3. Click 'Draft a new release'"
-echo "  4. Selecteaza tag-ul $VERSION"
-echo "  5. Incarca fisierul $ZIP_NAME"
+echo "  2. gh release create $VERSION '$RELEASE_DIR/$ZIP_NAME' --repo sudondream/cei-pdf-signer"
+echo ""
+echo "ATENTIE: incarca EXACT fisierul $ZIP_NAME generat mai sus."
+echo "Nu re-arhiva aplicatia cu Finder sau cu alte unelte - se pierd"
+echo "symlink-urile si aplicatia nu mai porneste (issues #4, #6, #7)."
 echo ""

--- a/scripts/verify-release-archive.sh
+++ b/scripts/verify-release-archive.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Verifica integritatea unei arhive de release inainte de publicare.
+#
+# DE CE EXISTA ACEST SCRIPT
+# -------------------------
+# Un bundle .app produs de PyInstaller contine ~45 de symlink-uri si depinde
+# de bitii de executie POSIX. Arhivele create cu unelte care nu pastreaza
+# aceste atribute (Finder pe alte platforme, `python -m zipfile`, uploadere
+# de artefacte, `zip` fara `-y`) distrug bundle-ul in mod silentios:
+#
+#   - Contents/MacOS/<app> isi pierde bitul de executie
+#       -> macOS: "The application <app> can't be opened."   (issues #4, #6)
+#   - Contents/Frameworks/python3.X (symlink -> python3__dot__X) devine
+#     un director GOL
+#       -> ModuleNotFoundError: No module named '_struct'     (issues #6, #7)
+#   - Contents/Resources/templates devine un director GOL
+#       -> jinja2.exceptions.TemplateNotFound: index.html
+#
+# Amprenta comuna: un symlink dereferentiat devine un director gol.
+# Un build corect NU contine niciun director gol.
+#
+# Utilizare:
+#   scripts/verify-release-archive.sh <arhiva.zip> [referinta.app]
+#
+# Daca se da si bundle-ul de referinta (cel din dist/), se compara si
+# numarul de symlink-uri.
+
+set -euo pipefail
+
+ARCHIVE="${1:-}"
+REFERENCE="${2:-}"
+
+if [ -z "$ARCHIVE" ]; then
+    echo "Utilizare: $0 <arhiva.zip> [referinta.app]" >&2
+    exit 2
+fi
+
+if [ ! -f "$ARCHIVE" ]; then
+    echo "EROARE: arhiva nu exista: $ARCHIVE" >&2
+    exit 2
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAILURES=0
+fail() { echo "  ✗ $1"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ✓ $1"; }
+
+echo "=== Verificare arhiva de release ==="
+echo "Arhiva: $ARCHIVE"
+echo ""
+
+# Extrage exact cum o face macOS pentru utilizator
+ditto -x -k "$ARCHIVE" "$TMP/extracted"
+
+APP="$(find "$TMP/extracted" -maxdepth 1 -name '*.app' -print -quit)"
+if [ -z "$APP" ]; then
+    echo "EROARE: arhiva nu contine niciun bundle .app in radacina" >&2
+    exit 1
+fi
+APP_NAME="$(basename "$APP" .app)"
+EXECUTABLE="$APP/Contents/MacOS/$APP_NAME"
+
+echo "--- 1. Structura bundle-ului ---"
+
+if [ -f "$EXECUTABLE" ]; then
+    pass "executabilul principal exista"
+else
+    fail "lipseste $EXECUTABLE"
+fi
+
+# Bitul de executie: fara el macOS refuza sa deschida aplicatia
+if [ -x "$EXECUTABLE" ]; then
+    pass "executabilul are bitul de executie"
+else
+    fail "executabilul NU are bitul de executie (arhiva a pierdut modurile POSIX)"
+fi
+
+echo ""
+echo "--- 2. Symlink-uri dereferentiate ---"
+
+# Amprenta principala: symlink-urile dereferentiate devin directoare goale
+EMPTY_DIRS="$(find "$APP" -type d -empty || true)"
+if [ -z "$EMPTY_DIRS" ]; then
+    pass "niciun director gol (symlink-urile sunt intacte)"
+else
+    COUNT="$(printf '%s\n' "$EMPTY_DIRS" | wc -l | tr -d ' ')"
+    fail "$COUNT directoare goale - symlink-uri dereferentiate de arhivator:"
+    printf '%s\n' "$EMPTY_DIRS" | sed "s|$APP|      .|"
+fi
+
+SYMLINKS="$(find "$APP" -type l | wc -l | tr -d ' ')"
+if [ -n "$REFERENCE" ] && [ -d "$REFERENCE" ]; then
+    REF_SYMLINKS="$(find "$REFERENCE" -type l | wc -l | tr -d ' ')"
+    if [ "$SYMLINKS" -eq "$REF_SYMLINKS" ]; then
+        pass "symlink-uri: $SYMLINKS (identic cu build-ul sursa)"
+    else
+        fail "symlink-uri: $SYMLINKS in arhiva vs $REF_SYMLINKS in $REFERENCE"
+    fi
+else
+    if [ "$SYMLINKS" -gt 0 ]; then
+        pass "symlink-uri pastrate: $SYMLINKS"
+    else
+        fail "arhiva nu contine niciun symlink - toate au fost dereferentiate"
+    fi
+fi
+
+echo ""
+echo "--- 3. Modulele native Python (_struct & co.) ---"
+
+# lib-dynload e accesibil doar prin symlink-ul python3.X -> python3__dot__X
+DYNLOAD="$(find "$APP/Contents/Frameworks" -maxdepth 2 -type d -name 'lib-dynload' -print -quit 2>/dev/null || true)"
+if [ -z "$DYNLOAD" ]; then
+    fail "lib-dynload negasit in bundle"
+else
+    VERSIONED="$(find "$APP/Contents/Frameworks" -maxdepth 1 -name 'python3.*' -print -quit 2>/dev/null || true)"
+    if [ -z "$VERSIONED" ]; then
+        fail "lipseste Contents/Frameworks/python3.X"
+    else
+        # -L: urmareste symlink-ul; daca e rupt/gol, nu gaseste nimic
+        STRUCT="$(find -L "$VERSIONED/lib-dynload" -maxdepth 1 -name '_struct*.so' -print -quit 2>/dev/null || true)"
+        if [ -n "$STRUCT" ]; then
+            pass "_struct accesibil prin $(basename "$VERSIONED")/lib-dynload"
+        else
+            fail "$(basename "$VERSIONED")/lib-dynload/_struct*.so INACCESIBIL (symlink rupt)"
+        fi
+    fi
+fi
+
+echo ""
+echo "--- 4. Test de pornire (smoke test) ---"
+
+if [ ! -x "$EXECUTABLE" ]; then
+    echo "  - sarit: executabilul nu poate fi rulat"
+    FAILURES=$((FAILURES + 1))
+else
+    LOG="$TMP/smoke.log"
+    "$EXECUTABLE" >"$LOG" 2>&1 &
+    PID=$!
+
+    STARTED=0
+    for _ in $(seq 1 60); do
+        if grep -q "Running on http" "$LOG" 2>/dev/null; then
+            STARTED=1
+            break
+        fi
+        if ! kill -0 "$PID" 2>/dev/null; then
+            break
+        fi
+        perl -e 'select(undef,undef,undef,0.5)'
+    done
+
+    kill "$PID" 2>/dev/null || true
+    wait "$PID" 2>/dev/null || true
+
+    if [ "$STARTED" -eq 1 ]; then
+        pass "aplicatia porneste si serverul Flask raspunde"
+    else
+        fail "aplicatia nu a pornit; output:"
+        sed 's/^/      /' "$LOG" | head -20
+    fi
+fi
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo "=== OK: arhiva este valida pentru publicare ==="
+    exit 0
+else
+    echo "=== ESEC: $FAILURES probleme. NU publica aceasta arhiva. ==="
+    echo ""
+    echo "Recreeaza arhiva cu ditto (pastreaza symlink-uri si permisiuni):"
+    echo "  ditto -c -k --sequesterRsrc --keepParent 'CEI PDF Signer.app' arhiva.zip"
+    exit 1
+fi


### PR DESCRIPTION
## Root cause

The `v0.7-beta` release asset was archived by a tool that dereferences symlinks and stores no POSIX modes (`zipinfo` reports host system `fat`, external attributes `000000`). It was not produced by `build-release.sh`.

A PyInstaller `.app` carries 45 symlinks and depends on the exec bit:

| | source build | shipped release |
|---|---|---|
| symlinks | 45 | 0 |
| empty dirs | 0 | 29 |
| `MacOS/CEI PDF Signer` | `-rwxr-xr-x` | `-rw-r--r--` |

This accounts for every launch failure reported:

- no exec bit, so macOS refuses to open the bundle: **#4**, **#6**
- `Contents/Frameworks/python3.14` (symlink to `python3__dot__14`) became an empty directory, making `lib-dynload` unreachable: `ModuleNotFoundError: No module named '_struct'` in **#6**, **#7**
- `Contents/Resources/templates` also emptied, which would have been the next error: `TemplateNotFound: index.html`

Python 3.14 is not implicated. Restoring only the `python3.14` symlink in the downloaded bundle makes that same binary boot and serve Flask.

## Fix

- `build-release.sh` archives with `ditto -c -k --sequesterRsrc --keepParent` instead of `zip`, and fails the build if the resulting artifact does not verify.
- `scripts/verify-release-archive.sh` (new) checks the exec bit, the empty-directory fingerprint, symlink count against the source build, `_struct` reachability, and runs a real launch smoke test.

## Verification

Tested in both directions against real artifacts:

- the shipped `v0.7-beta` archive fails with 5 findings
- a `ditto` archive of the same app passes all checks, including boot

Existing suite: 40/40 passing.

Closes #4
Closes #6
Closes #7

https://claude.ai/code/session_01UwR3kWDYnrTxs7SaTSdLC1