### PR TITLE
Unlock encrypted PDFs before reading them

### DIFF
--- a/app.py
+++ b/app.py
@@ -210,6 +210,38 @@ MAX_PAGE_TREE_DEPTH = 64
 DEFAULT_MEDIA_BOX = [0.0, 0.0, 612.0, 792.0]  # US Letter
 
 
+def unlock_pdf(pdf_reader, password=None):
+    """Authenticate an encrypted PDF so its strings and streams can be read.
+
+    Nothing used to call this, so the first read of an encrypted object raised
+    "PdfKeyNotAvailableError: No key available to decrypt, please authenticate
+    first." The confusing part for users is that such a document opens in any
+    viewer without a prompt: publishers routinely encrypt with an owner
+    password only, to restrict printing or copying, leaving the user password
+    empty. The file is still encrypted, and the key still has to be derived
+    before any content can be read.
+
+    So an empty password is tried first, which covers that whole class without
+    bothering anybody. Raises ValueError with a message meant for the user when
+    the document genuinely needs one.
+    """
+    if pdf_reader.security_handler is None:
+        return
+
+    from pyhanko.pdf_utils.crypt import AuthStatus
+
+    result = pdf_reader.decrypt(password if password is not None else '')
+    if result.status != AuthStatus.FAILED:
+        return
+
+    if password:
+        raise ValueError('Parola introdusa nu este corecta pentru acest PDF.')
+    raise ValueError(
+        'Acest PDF este protejat cu parola si nu poate fi deschis pentru '
+        'semnare. Deschideti-l cu parola si salvati o copie fara protectie, '
+        'apoi incercati din nou.')
+
+
 def get_page_media_box(pdf_reader, page_ix):
     """MediaBox of page `page_ix`, walking the page tree and honouring inheritance.
 
@@ -228,9 +260,13 @@ def get_page_media_box(pdf_reader, page_ix):
     for _ in range(MAX_PAGE_TREE_DEPTH):
         if node is None:
             break
+        # get_object() throughout: in an encrypted document a lookup returns a
+        # proxy standing in for the decrypted value, and iterating that raised
+        # "TypeError: 'DecryptedObjectProxy' object is not iterable". It is a
+        # no-op on a direct object, so it costs nothing to always resolve.
         box = node.get('/MediaBox')
         if box is not None:
-            return [float(v) for v in box]
+            return [float(v.get_object()) for v in box.get_object()]
         parent = node.get('/Parent')
         node = parent.get_object() if parent is not None else None
 
@@ -290,13 +326,30 @@ def document_has_signature(pdf_reader):
         acro = pdf_reader.root.get('/AcroForm')
         if acro is None:
             return False
-        for ref in acro.get_object().get('/Fields', []):
+        # get_object() on every hop. In an encrypted document these come back
+        # as proxies for the decrypted value, and the bare forms silently
+        # failed: iterating the proxy raised, the except below turned that
+        # into False, and the guard stopped guarding on exactly the documents
+        # it was written for.
+        fields = acro.get_object().get('/Fields')
+        for ref in (fields.get_object() if fields is not None else []):
             field = ref.get_object()
-            if field.get('/FT') == '/Sig' and field.get('/V') is not None:
+            field_type = field.get('/FT')
+            value = field.get('/V')
+            if field_type is not None:
+                field_type = field_type.get_object()
+            if field_type == '/Sig' and value is not None:
                 return True
     except Exception:
         return False
     return False
+
+
+def get_page_count(pdf_reader):
+    """Number of pages, resolved through any decryption proxy."""
+    pages = pdf_reader.root['/Pages'].get_object()
+    count = pages.get('/Count', 0)
+    return int(count.get_object() if count is not None else 0)
 
 
 # DejaVu Sans covers every Romanian letter, in both the correct comma-below
@@ -710,9 +763,17 @@ def api_sign_pdf():
         # Prepare PDF writer (allow hybrid xref PDFs)
         from pyhanko.pdf_utils.reader import PdfFileReader
         pdf_reader = PdfFileReader(pdf_input, strict=False)
+
+        # Before anything reads page content. Most encrypted documents carry
+        # only an owner password and unlock silently; the rest need telling.
+        try:
+            unlock_pdf(pdf_reader, password=request.form.get('pdf_password') or None)
+        except ValueError as e:
+            return jsonify({'error': str(e), 'needs_password': True}), 400
+
         pdf_writer = IncrementalPdfFileWriter.from_reader(pdf_reader)
 
-        page_count = int(pdf_reader.root['/Pages'].get('/Count', 0))
+        page_count = get_page_count(pdf_reader)
 
         # Add signature field if visible
         if visible:

--- a/test_app.py
+++ b/test_app.py
@@ -517,6 +517,159 @@ class NoPyKCS11Tests(unittest.TestCase):
                         "python-pkcs11 is importable, so the flag must be True")
 
 
+def build_encrypted_pdf(owner_pass='owner-secret', user_pass=''):
+    """A one page PDF with standard security. Empty user_pass is the common case.
+
+    Insurers and banks routinely ship documents encrypted with an owner
+    password only. They open in any viewer with no prompt, so users have no
+    idea they are encrypted, but their strings and streams still have to be
+    decrypted before anything can be read.
+    """
+    from io import BytesIO
+    from pyhanko.pdf_utils.writer import PdfFileWriter
+    from pyhanko.pdf_utils import generic
+
+    writer = PdfFileWriter()
+    contents = writer.add_object(generic.StreamObject(stream_data=b'BT ET'))
+    writer.insert_page(generic.DictionaryObject({
+        generic.NameObject('/Type'): generic.NameObject('/Page'),
+        generic.NameObject('/MediaBox'): generic.ArrayObject(
+            map(generic.NumberObject, [0, 0, 595, 842])),
+        generic.NameObject('/Resources'): generic.DictionaryObject(),
+        generic.NameObject('/Contents'): contents,
+    }))
+    writer.encrypt(owner_pass=owner_pass, user_pass=user_pass)
+    buf = BytesIO()
+    writer.write(buf)
+    return buf.getvalue()
+
+
+class EncryptedPdfTests(unittest.TestCase):
+    """Encrypted PDFs must be unlocked before anything reads their content.
+
+    Reported as "PdfKeyNotAvailableError: No key available to decrypt, please
+    authenticate first." on an RCA renewal document. Nothing ever called
+    decrypt(), so the first read of an encrypted string or stream failed. The
+    document opened fine in a viewer, because it carried only an owner
+    password, which is why it looked like the app was at fault for no reason.
+    """
+
+    def _reader(self, data):
+        from io import BytesIO
+        from pyhanko.pdf_utils.reader import PdfFileReader
+        return PdfFileReader(BytesIO(data), strict=False)
+
+    def test_owner_password_only_is_unlocked_automatically(self):
+        """The common case: no user password, so no reason to ask the user."""
+        reader = self._reader(build_encrypted_pdf())
+        app_module.unlock_pdf(reader)
+        page = reader.find_page_for_modification(0)[0].get_object()
+        self.assertEqual(page.raw_get('/Contents').get_object().data, b'BT ET',
+                         "content stream must be readable once unlocked")
+
+    def test_unencrypted_pdf_is_left_alone(self):
+        reader = self._reader(build_nested_page_tree_pdf())
+        app_module.unlock_pdf(reader)  # must not raise
+
+    def test_real_user_password_reports_something_actionable(self):
+        """A genuinely password protected file needs a message, not a traceback."""
+        reader = self._reader(build_encrypted_pdf(user_pass='hunter2'))
+        with self.assertRaises(ValueError) as caught:
+            app_module.unlock_pdf(reader)
+        message = str(caught.exception).lower()
+        self.assertIn('parol', message,
+                      "the message has to tell the user it wants a password")
+
+    def test_supplied_password_unlocks_the_document(self):
+        reader = self._reader(build_encrypted_pdf(user_pass='hunter2'))
+        app_module.unlock_pdf(reader, password='hunter2')
+        page = reader.find_page_for_modification(0)[0].get_object()
+        self.assertEqual(page.raw_get('/Contents').get_object().data, b'BT ET')
+
+    def test_media_box_survives_decryption(self):
+        """Values read out of an encrypted document arrive wrapped.
+
+        In an encrypted file a dictionary lookup hands back a proxy standing in
+        for the decrypted object, so iterating it directly raised
+        "TypeError: 'DecryptedObjectProxy' object is not iterable" and the
+        signature never got placed. Separate from the missing decrypt() call,
+        and only reachable once that one is fixed.
+        """
+        reader = self._reader(build_encrypted_pdf())
+        app_module.unlock_pdf(reader)
+        self.assertEqual(app_module.get_page_media_box(reader, 0),
+                         [0.0, 0.0, 595.0, 842.0])
+
+    def test_existing_signature_is_still_detected_when_encrypted(self):
+        """The guard against stamping over a signature must not quietly lapse.
+
+        document_has_signature swallows exceptions and reports False, so once
+        an encrypted document made the field lookup raise, the guard silently
+        stopped guarding: the app would stamp page content on an already
+        signed file and invalidate the signature it was meant to protect.
+        """
+        from io import BytesIO
+        from pyhanko.pdf_utils.writer import PdfFileWriter
+        from pyhanko.pdf_utils import generic
+
+        def build(encrypt):
+            writer = PdfFileWriter()
+            writer.insert_page(generic.DictionaryObject({
+                generic.NameObject('/Type'): generic.NameObject('/Page'),
+                generic.NameObject('/MediaBox'): generic.ArrayObject(
+                    map(generic.NumberObject, [0, 0, 595, 842])),
+                generic.NameObject('/Resources'): generic.DictionaryObject(),
+            }))
+            field = writer.add_object(generic.DictionaryObject({
+                generic.NameObject('/FT'): generic.NameObject('/Sig'),
+                generic.NameObject('/T'): generic.TextStringObject('Signature1'),
+                generic.NameObject('/V'): generic.DictionaryObject({
+                    generic.NameObject('/Type'): generic.NameObject('/Sig'),
+                }),
+            }))
+            writer.root[generic.NameObject('/AcroForm')] = writer.add_object(
+                generic.DictionaryObject({
+                    generic.NameObject('/Fields'): generic.ArrayObject([field]),
+                }))
+            writer.update_root()
+            if encrypt:
+                writer.encrypt(owner_pass='owner-secret', user_pass='')
+            buf = BytesIO()
+            writer.write(buf)
+            return buf.getvalue()
+
+        plain = self._reader(build(encrypt=False))
+        self.assertTrue(app_module.document_has_signature(plain),
+                        "sanity: a signed document must be detected when unencrypted")
+
+        encrypted = self._reader(build(encrypt=True))
+        app_module.unlock_pdf(encrypted)
+        self.assertTrue(app_module.document_has_signature(encrypted),
+                        "encryption must not disable the existing-signature guard")
+
+    def test_page_count_is_readable_when_encrypted(self):
+        reader = self._reader(build_encrypted_pdf())
+        app_module.unlock_pdf(reader)
+        self.assertEqual(app_module.get_page_count(reader), 1)
+
+    def test_stamping_works_on_an_encrypted_document(self):
+        """End to end: the path that failed for the reporter."""
+        from io import BytesIO
+        from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+
+        reader = self._reader(build_encrypted_pdf())
+        app_module.unlock_pdf(reader)
+        writer = IncrementalPdfFileWriter.from_reader(reader)
+        applied = app_module.apply_visual_stamps(
+            writer, reader,
+            [{'page': 1, 'x': 40, 'y': 40, 'width': 300, 'height': 90}],
+            1, 'ADRIAN BANCU', '2026-08-06 12:00')
+        self.assertEqual(applied, 1)
+        out = BytesIO()
+        writer.write(out)
+        self.assertTrue(out.getvalue().startswith(b'%PDF'))
+
+
 class RomanianDiacriticsTests(unittest.TestCase):
     """The signature appearance has to render Romanian names correctly.
 


### PR DESCRIPTION
Closes #1.

## Root cause

Signing failed with `PdfKeyNotAvailableError: No key available to decrypt, please authenticate first.` Nothing ever called `decrypt()`, so the first read of an encrypted string or stream raised.

What made it look arbitrary to the reporter is that the document opens in any viewer **with no prompt at all**. Publishers routinely encrypt with an owner password only, to restrict printing or copying, leaving the user password empty. The file is still encrypted and the key still has to be derived, but nothing in the user's experience suggests that, so the app appeared to reject an ordinary PDF for no reason. @gabidj's guess in the thread was close: the file *is* special, just not visibly so.

`unlock_pdf()` tries an empty password first, covering that entire class silently, and raises a message aimed at the user when a document genuinely needs one.

## Two further defects behind it

Both only reachable on encrypted documents, and neither would have been found without fixing the first.

**1. Values arrive wrapped.** In an encrypted file a dictionary lookup returns a proxy standing in for the decrypted value. `get_page_media_box` iterated it directly:

```
TypeError: 'DecryptedObjectProxy' object is not iterable
```

so the signature never got placed. `get_object()` is a no-op on a direct object, so it is now called on every hop.

**2. The existing-signature guard silently lapsed.** `document_has_signature` swallows exceptions and reports `False`. Once the field lookup started raising on encrypted documents, the guard stopped guarding: the app would stamp page content onto an already signed file and **invalidate the signature it exists to protect**. That one fails quietly and would never have arrived as a bug report.

## Verification

End to end, not unit tests alone. An encrypted PDF is unlocked, stamped, signed with a real certificate, written out, reopened, and its signature field read back:

```
SIGNED encrypted PDF ok, bytes: 16583
signature fields present: ['Signature1']
```

Rendered and inspected: the signature appears correctly, and the Romanian name in the certificate CN (`ȘTEFAN RUSIE`) displays properly, confirming this composes with #5.

57 tests passing.

## Note

`/api/sign` accepts an optional `pdf_password` for documents that genuinely need one. The bundled UI does not prompt for it yet, so those documents currently get the instruction to save an unprotected copy instead. Happy to add a prompt as a follow-up.

https://claude.ai/code/session_01UwR3kWDYnrTxs7SaTSdLC1