### PR TITLE
Point the download links straight at the latest zip

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -467,7 +467,7 @@
         <p data-lang="en">Free, open-source application for digitally signing PDF documents using the Romanian Electronic Identity Card.</p>
         <p data-lang="ro">Aplicatie gratuita si open-source pentru semnarea digitala a documentelor PDF folosind Cartea de Identitate Electronica din Romania.</p>
         <div class="cta-buttons">
-            <a href="https://github.com/sudondream/cei-pdf-signer/releases" class="btn btn-primary">
+            <a href="https://github.com/sudondream/cei-pdf-signer/releases/download/v0.10-beta/CEI-PDF-Signer-v0.10-beta-macOS.zip" class="btn btn-primary">
                 <span>⬇️</span>
                 <span data-lang="en">Download for macOS</span>
                 <span data-lang="ro">Descarca pentru macOS</span>
@@ -625,7 +625,7 @@
                     <p data-lang="en">Get the latest release from GitHub</p>
                     <p data-lang="ro">Descarca ultima versiune de pe GitHub</p>
                     <code>
-                        <a href="https://github.com/sudondream/cei-pdf-signer/releases" target="_blank" style="color: var(--accent)">github.com/sudondream/cei-pdf-signer/releases</a>
+                        <a href="https://github.com/sudondream/cei-pdf-signer/releases/download/v0.10-beta/CEI-PDF-Signer-v0.10-beta-macOS.zip" target="_blank" style="color: var(--accent)">CEI-PDF-Signer-v0.10-beta-macOS.zip</a>
                     </code>
                 </div>
             </div>


### PR DESCRIPTION
## What

The landing page sent every download link to the releases listing page. Both now point directly at the `v0.10-beta` archive.

| Location | Before | After |
|---|---|---|
| Hero button (line 470) | `/releases` | `/releases/download/v0.10-beta/CEI-PDF-Signer-v0.10-beta-macOS.zip` |
| Install step 2 (line 628) | `/releases` | same direct link, labelled with the filename |

Footer `Releases` / `Versiuni` links are deliberately untouched — those are navigation to the release history, not download actions.

## Why

Sending people to the listing page makes them work out which entry is current. That page does not order reliably: `v0.10-beta` renders **third**, below `v0.9-beta` and `v0.8-beta`, despite being the newest by every date field and flagged `Latest` by the API. A visitor scanning from the top sees `v0.9-beta` first.

## Verified

- Direct URL returns HTTP 200 anonymously, and the payload starts with the `PK` ZIP signature
- Archive checksum matches `SHA256SUMS.txt`: `fe55e983…c11d9f`

## Note on maintenance

The asset filename carries the version, so these two links need bumping each release. GitHub's `/releases/latest/download/<name>` shortcut cannot help while the filename changes. Publishing an additional version-less asset (`CEI-PDF-Signer-macOS.zip`) would make a permanent link possible — happy to add that to `build-release.sh` separately.

https://claude.ai/code/session_01BCvSHKzMYk3sQDgSygTqdA